### PR TITLE
Initial Proton support

### DIFF
--- a/unreal_modintegrator/build.rs
+++ b/unreal_modintegrator/build.rs
@@ -30,7 +30,7 @@ fn main() {
         panic!("git failed to finish {}", status);
     }
 
-    let version_selector = env::var_os("UE_VERSION_SELECTOR").expect("UE_VERISON_SELECTOR not set");
+    let version_selector = env::var_os("UE_VERSION_SELECTOR").expect("UE_VERSION_SELECTOR not set");
     let engine_path = env::var_os("UE_PATH").expect("UE_PATH not set");
 
     let project_file = project_dir.join("ModIntegrator.uproject");

--- a/unreal_modloader/src/game_path_helpers.rs
+++ b/unreal_modloader/src/game_path_helpers.rs
@@ -21,7 +21,7 @@ lazy_static! {
         Regex::new("(?x)<Identity(.*?)Publisher(.*?)Version=\"([^\"]*)\"").unwrap();
 }
 
-pub fn determine_installed_mods_path_steam(game_name: &str) -> Option<PathBuf> {
+pub fn determine_installed_mods_path_steam(game_name: &str, app_id: u32) -> Option<PathBuf> {
     let base_dirs = BaseDirs::new();
     if base_dirs.is_none() {
         warn!("Could not determine base directory");
@@ -30,6 +30,23 @@ pub fn determine_installed_mods_path_steam(game_name: &str) -> Option<PathBuf> {
     let base_dirs = base_dirs.unwrap();
 
     let data_dir = base_dirs.data_local_dir();
+    let base_path = Some(data_dir.join(game_name).join("Saved").join("Paks"));
+    trace!("base_path: {:?}", base_path);
+
+    base_path
+}
+
+pub fn determine_installed_mods_path_proton(game_name: &str, app_id: u32) -> Option<PathBuf> {
+    let data_dir: PathBuf = SteamDir::locate()?.path
+                .join("steamapps")
+                .join("compatdata")
+                .join(app_id.to_string())
+                .join("pfx")
+                .join("drive_c")
+                .join("users")
+                .join("steamuser")
+                .join("AppData")
+                .join("Local");
     let base_path = Some(data_dir.join(game_name).join("Saved").join("Paks"));
     trace!("base_path: {:?}", base_path);
 

--- a/unreal_modloader/src/game_path_helpers.rs
+++ b/unreal_modloader/src/game_path_helpers.rs
@@ -21,7 +21,7 @@ lazy_static! {
         Regex::new("(?x)<Identity(.*?)Publisher(.*?)Version=\"([^\"]*)\"").unwrap();
 }
 
-pub fn determine_installed_mods_path_steam(game_name: &str, app_id: u32) -> Option<PathBuf> {
+pub fn determine_installed_mods_path_steam(game_name: &str) -> Option<PathBuf> {
     let base_dirs = BaseDirs::new();
     if base_dirs.is_none() {
         warn!("Could not determine base directory");

--- a/unreal_modloader/src/game_platform_managers.rs
+++ b/unreal_modloader/src/game_platform_managers.rs
@@ -50,7 +50,7 @@ impl InstallManager for SteamInstallManager {
     fn get_paks_path(&self) -> Option<PathBuf> {
         if self.mods_path.borrow().is_none() {
             *self.mods_path.borrow_mut() =
-                game_path_helpers::determine_installed_mods_path_steam(self.game_name, self.app_id);
+                game_path_helpers::determine_installed_mods_path_steam(self.game_name);
         }
         self.mods_path.borrow().clone()
     }


### PR DESCRIPTION
Allows detection for Proton-based games on Linux.
Currently, it defaults to assuming that games on Linux are Proton-based, but this could be configurable by individual modloaders.