### PR TITLE
unreal_asset: better support for delegate properties

### DIFF
--- a/unreal_asset/src/properties/delegate_property.rs
+++ b/unreal_asset/src/properties/delegate_property.rs
@@ -12,8 +12,8 @@ use crate::unreal_types::{FName, Guid, PackageIndex};
 
 #[derive(Hash, Clone, PartialEq, Eq)]
 pub struct MulticastDelegate {
-    object: PackageIndex,
-    delegate: FName,
+    pub object: PackageIndex,
+    pub delegate: FName,
 }
 
 #[derive(Hash, Clone, PartialEq, Eq)]

--- a/unreal_asset/src/properties/material_input_property.rs
+++ b/unreal_asset/src/properties/material_input_property.rs
@@ -17,11 +17,11 @@ use crate::unreal_types::{FName, Guid};
 
 #[derive(Hash, Clone, PartialEq, Eq)]
 pub struct MaterialExpression {
-    name: FName,
-    extras: Vec<u8>,
-    output_index: i32,
-    input_name: FName,
-    expression_name: FName,
+    pub name: FName,
+    pub extras: Vec<u8>,
+    pub output_index: i32,
+    pub input_name: FName,
+    pub expression_name: FName,
 }
 
 #[derive(Hash, Clone, PartialEq, Eq)]

--- a/unreal_asset/src/properties/mod.rs
+++ b/unreal_asset/src/properties/mod.rs
@@ -732,7 +732,10 @@ impl Property {
                     .into()
             }
 
-            "MulticastDelegateProperty" => MulticastDelegateProperty::new(
+            "MulticastDelegateProperty"
+            | "DelegateProperty"
+            | "MulticastSparseDelegateProperty"
+            | "MulticastInlineDelegateProperty" => MulticastDelegateProperty::new(
                 asset,
                 name,
                 include_header,

--- a/unreal_asset/src/types.rs
+++ b/unreal_asset/src/types.rs
@@ -13,6 +13,16 @@ impl<T> Vector<T> {
     }
 }
 
+impl<T: Copy> From<[T; 3]> for Vector<T> {
+    fn from(src: [T; 3]) -> Self {
+        Self {
+            x: src[0],
+            y: src[1],
+            z: src[2],
+        }
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Vector4<T> {
     pub x: T,
@@ -27,12 +37,34 @@ impl<T> Vector4<T> {
     }
 }
 
+impl<T: Copy> From<[T; 4]> for Vector4<T> {
+    fn from(src: [T; 4]) -> Self {
+        Self {
+            x: src[0],
+            y: src[1],
+            z: src[2],
+            w: src[3],
+        }
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Color<T> {
     pub r: T,
     pub g: T,
     pub b: T,
     pub a: T,
+}
+
+impl<T: Copy> From<[T; 4]> for Color<T> {
+    fn from(src: [T; 4]) -> Self {
+        Self {
+            r: src[0],
+            g: src[1],
+            b: src[2],
+            a: src[3],
+        }
+    }
 }
 
 impl<T> Color<T> {

--- a/unreal_modmetadata/src/lib.rs
+++ b/unreal_modmetadata/src/lib.rs
@@ -208,6 +208,6 @@ mod tests {
             }
         "#;
 
-        assert_eq!(true, from_slice(src.as_bytes()).is_err());
+        assert!(from_slice(src.as_bytes()).is_err());
     }
 }


### PR DESCRIPTION
- publicised MulticastDelegate and MaterialExpression struct
- allows MulticastDelegateProperty to be built from more types of Delegate property (they are all serialised the same)
- added an impl for From<[T: Copy;4]> for primitive types
- fixed a modmetadata clippy warning