### PR TITLE
Make Asset generic

### DIFF
--- a/unreal_asset/src/containers/chain.rs
+++ b/unreal_asset/src/containers/chain.rs
@@ -1,0 +1,74 @@
+use std::io::{Error, ErrorKind, Read, Seek, SeekFrom};
+
+pub struct Chain<C: Read + Seek> {
+    middle: u64,
+    size: u64,
+    first: C,
+    second: Option<C>,
+    pos: u64,
+}
+
+impl<C: Read + Seek> Chain<C> {
+    pub fn new(mut first: C, mut second: Option<C>) -> Self {
+        let middle = first.seek(SeekFrom::End(0)).unwrap_or_default();
+        let size = match second.as_mut() {
+            Some(second) => second.seek(SeekFrom::End(0)).unwrap_or_default(),
+            None => middle,
+        };
+        Self {
+            middle,
+            size,
+            first,
+            second,
+            pos: 0,
+        }
+    }
+}
+
+impl<C: Read + Seek> Read for Chain<C> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.pos = if self.pos > self.middle {
+            match self.second.as_mut() {
+                Some(second) => second.read(buf)? as u64 + self.middle,
+                None => return Err(Error::new(ErrorKind::UnexpectedEof, "read past eof")),
+            }
+        } else if buf.len() as u64 <= self.middle - self.pos {
+            self.first.read(buf)? as u64
+        } else {
+            let mut part1 = Vec::new();
+            let mut seek = self.first.read_to_end(&mut part1).unwrap_or_default() as u64;
+            let mut part2 = Vec::with_capacity(buf.len() - seek as usize);
+            seek += part2.capacity() as u64;
+            match self.second.as_mut() {
+                Some(second) => second.read_exact(&mut part2).unwrap_or_default(),
+                None => return Err(Error::new(ErrorKind::UnexpectedEof, "read past eof")),
+            }
+            part1.append(&mut part2);
+            buf.copy_from_slice(&part1);
+            self.pos + seek
+        };
+        Ok(self.pos as usize)
+    }
+}
+
+impl<C: Read + Seek> Seek for Chain<C> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.pos = match pos {
+            SeekFrom::Start(offset) => match offset > self.size {
+                true => return Err(Error::new(ErrorKind::UnexpectedEof, "seeked out of file")),
+                false => offset,
+            },
+            SeekFrom::End(offset) => match offset > self.size as i64 {
+                true => return Err(Error::new(ErrorKind::UnexpectedEof, "seeked out of file")),
+                false => self.size - offset as u64,
+            },
+            SeekFrom::Current(offset) => match self.pos as i64 + offset {
+                res if res > self.size as i64 || res.is_negative() => {
+                    return Err(Error::new(ErrorKind::UnexpectedEof, "seeked out of file"))
+                }
+                res => res as u64,
+            },
+        };
+        Ok(self.pos)
+    }
+}

--- a/unreal_asset/src/containers/indexed_map/mod.rs
+++ b/unreal_asset/src/containers/indexed_map/mod.rs
@@ -525,7 +525,7 @@ where
             });
         }
 
-        return Entry::Vacant(VacantEntry { key, map: self });
+        Entry::Vacant(VacantEntry { key, map: self })
     }
 
     pub fn get_by_key<Q>(&self, key: &Q) -> Option<&V>

--- a/unreal_asset/src/containers/mod.rs
+++ b/unreal_asset/src/containers/mod.rs
@@ -1,1 +1,2 @@
+pub mod chain;
 pub mod indexed_map;

--- a/unreal_asset/src/cursor_ext.rs
+++ b/unreal_asset/src/cursor_ext.rs
@@ -1,4 +1,4 @@
-//! Cursor extensions for easier deserialization
+//! Read and Seek extensions for easier deserialization
 
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;

--- a/unreal_asset/src/cursor_ext.rs
+++ b/unreal_asset/src/cursor_ext.rs
@@ -1,25 +1,27 @@
 //! Cursor extensions for easier deserialization
 
-use std::io::{Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::error::Error;
 
-pub trait CursorExt {
+pub trait ReadExt {
     /// Read string of format \<length i32\>\<string\>\<null\>
     fn read_string(&mut self) -> Result<Option<String>, Error>;
     /// Read u8 as bool
     fn read_bool(&mut self) -> Result<bool, Error>;
+}
 
+pub trait WriteExt {
     /// Write string of format \<length i32\>\<string\>\<null\>
     fn write_string(&mut self, string: &Option<String>) -> Result<usize, Error>;
     /// Write bool as u8
     fn write_bool(&mut self, value: bool) -> Result<(), Error>;
 }
 
-impl CursorExt for Cursor<Vec<u8>> {
+impl<R: Read + Seek> ReadExt for R {
     // read string of format <length i32><string><null>
     fn read_string(&mut self) -> Result<Option<String>, Error> {
         let len = self.read_i32::<LittleEndian>()?;
@@ -70,7 +72,9 @@ impl CursorExt for Cursor<Vec<u8>> {
         let res = self.read_u8()?;
         Ok(res > 0)
     }
+}
 
+impl<W: Write> WriteExt for W {
     fn write_string(&mut self, string: &Option<String>) -> Result<usize, Error> {
         if string.is_none() {
             self.write_i32::<LittleEndian>(0)?;

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -72,7 +72,7 @@ pub mod unversioned;
 pub mod uproperty;
 
 use containers::indexed_map::IndexedMap;
-use cursor_ext::CursorExt;
+use cursor_ext::{ReadExt, WriteExt};
 use custom_version::{CustomVersion, CustomVersionTrait};
 use engine_version::{get_object_versions, guess_engine_version, EngineVersion};
 use error::Error;

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -44,7 +44,7 @@
 use std::collections::hash_map::DefaultHasher;
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
-use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
@@ -160,10 +160,9 @@ struct AssetHeader {
 
 //#[derive(Debug)]
 /// Unreal Engine uasset
-pub struct Asset {
+pub struct Asset<C: Read + Seek> {
     // raw data
-    cursor: Cursor<Vec<u8>>,
-    data_length: u64,
+    cursor: C,
 
     // parsed data
     pub info: String,
@@ -229,14 +228,16 @@ pub struct Asset {
     parent_class: Option<ParentClassInfo>,
 }
 
-struct AssetSerializer<'asset, 'cursor> {
-    asset: &'asset Asset,
-    cursor: &'cursor mut Cursor<Vec<u8>>,
+struct AssetSerializer<'asset, 'cursor, W: Read + Seek + Write, C: Read + Seek> {
+    asset: &'asset Asset<C>,
+    cursor: &'cursor mut W,
     cached_parent_info: Option<ParentClassInfo>,
 }
 
-impl<'asset, 'cursor> AssetSerializer<'asset, 'cursor> {
-    pub fn new(asset: &'asset Asset, cursor: &'cursor mut Cursor<Vec<u8>>) -> Self {
+impl<'asset, 'cursor, W: Read + Seek + Write, C: Read + Seek>
+    AssetSerializer<'asset, 'cursor, W, C>
+{
+    pub fn new(asset: &'asset Asset<C>, cursor: &'cursor mut W) -> Self {
         AssetSerializer {
             asset,
             cursor,
@@ -245,7 +246,9 @@ impl<'asset, 'cursor> AssetSerializer<'asset, 'cursor> {
     }
 }
 
-impl<'asset, 'cursor> AssetTrait for AssetSerializer<'asset, 'cursor> {
+impl<'asset, 'cursor, W: Read + Seek + Write, C: Read + Seek> AssetTrait
+    for AssetSerializer<'asset, 'cursor, W, C>
+{
     fn get_custom_version<T>(&self) -> CustomVersion
     where
         T: CustomVersionTrait + Into<i32>,
@@ -253,12 +256,12 @@ impl<'asset, 'cursor> AssetTrait for AssetSerializer<'asset, 'cursor> {
         self.asset.get_custom_version::<T>()
     }
 
-    fn position(&self) -> u64 {
-        self.cursor.position()
+    fn position(&mut self) -> u64 {
+        self.cursor.stream_position().unwrap_or_default()
     }
 
     fn set_position(&mut self, pos: u64) {
-        self.cursor.set_position(pos)
+        self.cursor.seek(SeekFrom::Start(pos)).unwrap_or_default();
     }
 
     fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
@@ -336,7 +339,9 @@ impl<'asset, 'cursor> AssetTrait for AssetSerializer<'asset, 'cursor> {
     }
 }
 
-impl<'asset, 'cursor> AssetWriter for AssetSerializer<'asset, 'cursor> {
+impl<'asset, 'cursor, W: Seek + Read + Write, C: Seek + Read> AssetWriter
+    for AssetSerializer<'asset, 'cursor, W, C>
+{
     fn write_property_guid(&mut self, guid: &Option<Guid>) -> Result<(), Error> {
         if self.asset.object_version >= ObjectVersion::VER_UE4_PROPERTY_GUID_IN_PROPERTY_TAG {
             self.cursor.write_bool(guid.is_some())?;
@@ -415,7 +420,7 @@ impl<'asset, 'cursor> AssetWriter for AssetSerializer<'asset, 'cursor> {
     }
 }
 
-impl AssetTrait for Asset {
+impl<C: Read + Seek> AssetTrait for Asset<C> {
     fn get_custom_version<T>(&self) -> CustomVersion
     where
         T: CustomVersionTrait + Into<i32>,
@@ -432,12 +437,12 @@ impl AssetTrait for Asset {
             .unwrap_or_else(|| CustomVersion::new(T::GUID, 0))
     }
 
-    fn position(&self) -> u64 {
-        self.cursor.position()
+    fn position(&mut self) -> u64 {
+        self.cursor.stream_position().unwrap_or_default()
     }
 
     fn set_position(&mut self, pos: u64) {
-        self.cursor.set_position(pos)
+        self.cursor.seek(SeekFrom::Start(pos)).unwrap_or_default();
     }
 
     fn seek(&mut self, style: SeekFrom) -> io::Result<u64> {
@@ -528,7 +533,7 @@ impl AssetTrait for Asset {
     }
 }
 
-impl AssetReader for Asset {
+impl<C: Read + Seek> AssetReader for Asset<C> {
     fn read_property_guid(&mut self) -> Result<Option<Guid>, Error> {
         if self.object_version >= ObjectVersion::VER_UE4_PROPERTY_GUID_IN_PROPERTY_TAG {
             let has_property_guid = self.cursor.read_bool()?;
@@ -624,23 +629,16 @@ impl AssetReader for Asset {
     }
 }
 
-impl<'a> Asset {
+impl<'a, C: Read + Seek> Asset<C> {
     /// Create an asset from a binary file
-    pub fn new(asset_data: Vec<u8>, bulk_data: Option<Vec<u8>>) -> Self {
-        let raw_data = match &bulk_data {
-            Some(e) => {
-                let mut data = asset_data;
-                data.extend(e);
-                data
-            }
-            None => asset_data,
-        };
-
+    pub fn new(asset_data: C, bulk_data: Option<C>) -> Self {
         Asset {
-            data_length: raw_data.len() as u64,
-            cursor: Cursor::new(raw_data),
-            info: String::from("Serialized with unrealmodding/uasset"),
             use_separate_bulk_data_files: bulk_data.is_some(),
+            cursor: match bulk_data {
+                Some(bulk) => todo!("create custom chain type"),
+                None => asset_data,
+            },
+            info: String::from("Serialized with unrealmodding/uasset"),
             object_version: ObjectVersion::UNKNOWN,
             object_version_ue5: ObjectVersionUE5::UNKNOWN,
             legacy_file_version: 0,
@@ -922,6 +920,13 @@ impl<'a> Asset {
             self.preload_dependency_offset = self.cursor.read_i32::<LittleEndian>()?;
         }
         Ok(())
+    }
+
+    pub fn data_length(&mut self) -> u64 {
+        let pos = self.cursor.stream_position().unwrap_or_default();
+        let len = self.cursor.seek(SeekFrom::End(0)).unwrap_or_default();
+        self.cursor.seek(SeekFrom::Start(pos)).unwrap_or_default();
+        len
     }
 
     fn read_name_map_string(&mut self) -> Result<(u32, String), Error> {
@@ -1295,9 +1300,9 @@ impl<'a> Asset {
         let next_starting = match i < (self.exports.len() - 1) {
             true => match &self.exports[i + 1] {
                 Export::BaseExport(next_export) => next_export.serial_offset as u64,
-                _ => self.data_length - 4,
+                _ => self.data_length() - 4,
             },
-            false => self.data_length - 4,
+            false => self.data_length() - 4,
         };
 
         self.cursor
@@ -1368,7 +1373,8 @@ impl<'a> Asset {
             }
         };
 
-        let extras_len = next_starting as i64 - self.cursor.position() as i64;
+        let extras_len =
+            next_starting as i64 - self.cursor.stream_position().unwrap_or_default() as i64;
         if extras_len < 0 {
             // todo: warning?
 
@@ -1573,10 +1579,10 @@ impl<'a> Asset {
         Ok(())
     }
 
-    pub fn write_data(
+    pub fn write_data<W: Read + Seek + Write>(
         &self,
-        cursor: &mut Cursor<Vec<u8>>,
-        uexp_cursor: Option<&mut Cursor<Vec<u8>>>,
+        cursor: &mut W,
+        uexp_cursor: Option<&mut W>,
     ) -> Result<(), Error> {
         if self.use_separate_bulk_data_files != uexp_cursor.is_some() {
             return Err(Error::no_data(format!(
@@ -1820,10 +1826,9 @@ impl<'a> Asset {
 }
 
 // custom debug implementation to not print the whole data buffer
-impl Debug for Asset {
+impl<C: Read + Seek> Debug for Asset<C> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_struct("Asset")
-            .field("data_len", &self.cursor.get_ref().len())
             .field("info", &self.info)
             .field(
                 "use_separate_bulk_data_files",
@@ -1913,7 +1918,7 @@ impl FEngineVersion {
         }
     }
 
-    fn read(cursor: &mut Cursor<Vec<u8>>) -> Result<Self, Error> {
+    fn read<C: Read + Seek>(cursor: &mut C) -> Result<Self, Error> {
         let major = cursor.read_u16::<LittleEndian>()?;
         let minor = cursor.read_u16::<LittleEndian>()?;
         let patch = cursor.read_u16::<LittleEndian>()?;

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -71,6 +71,7 @@ pub mod types;
 pub mod unversioned;
 pub mod uproperty;
 
+use containers::chain::Chain;
 use containers::indexed_map::IndexedMap;
 use cursor_ext::{ReadExt, WriteExt};
 use custom_version::{CustomVersion, CustomVersionTrait};
@@ -162,7 +163,7 @@ struct AssetHeader {
 /// Unreal Engine uasset
 pub struct Asset<C: Read + Seek> {
     // raw data
-    cursor: C,
+    cursor: Chain<C>,
 
     // parsed data
     pub info: String,
@@ -339,7 +340,7 @@ impl<'asset, 'cursor, W: Read + Seek + Write, C: Read + Seek> AssetTrait
     }
 }
 
-impl<'asset, 'cursor, W: Seek + Read + Write, C: Seek + Read> AssetWriter
+impl<'asset, 'cursor, W: Seek + Read + Write, C: Read + Seek> AssetWriter
     for AssetSerializer<'asset, 'cursor, W, C>
 {
     fn write_property_guid(&mut self, guid: &Option<Guid>) -> Result<(), Error> {
@@ -634,10 +635,7 @@ impl<'a, C: Read + Seek> Asset<C> {
     pub fn new(asset_data: C, bulk_data: Option<C>) -> Self {
         Asset {
             use_separate_bulk_data_files: bulk_data.is_some(),
-            cursor: match bulk_data {
-                Some(bulk) => todo!("create custom chain type"),
-                None => asset_data,
-            },
+            cursor: Chain::new(asset_data, bulk_data),
             info: String::from("Serialized with unrealmodding/uasset"),
             object_version: ObjectVersion::UNKNOWN,
             object_version_ue5: ObjectVersionUE5::UNKNOWN,

--- a/unreal_asset/src/reader/asset_trait.rs
+++ b/unreal_asset/src/reader/asset_trait.rs
@@ -13,7 +13,7 @@ pub trait AssetTrait {
     fn get_custom_version<T>(&self) -> CustomVersion
     where
         T: CustomVersionTrait + Into<i32>;
-    fn position(&self) -> u64;
+    fn position(&mut self) -> u64;
     fn set_position(&mut self, pos: u64);
     fn seek(&mut self, style: SeekFrom) -> io::Result<u64>;
 

--- a/unreal_asset/src/reader/raw_reader.rs
+++ b/unreal_asset/src/reader/raw_reader.rs
@@ -44,7 +44,7 @@ impl AssetTrait for RawReader {
         CustomVersion::new([0u8; 16], 0)
     }
 
-    fn position(&self) -> u64 {
+    fn position(&mut self) -> u64 {
         self.cursor.position()
     }
 

--- a/unreal_asset/src/reader/raw_reader.rs
+++ b/unreal_asset/src/reader/raw_reader.rs
@@ -3,7 +3,7 @@ use std::io::{self, Cursor, Read, Seek};
 use byteorder::{LittleEndian, ReadBytesExt};
 
 use crate::containers::indexed_map::IndexedMap;
-use crate::cursor_ext::CursorExt;
+use crate::cursor_ext::ReadExt;
 use crate::custom_version::{CustomVersion, CustomVersionTrait};
 use crate::engine_version::{guess_engine_version, EngineVersion};
 use crate::error::Error;

--- a/unreal_asset/src/reader/raw_writer.rs
+++ b/unreal_asset/src/reader/raw_writer.rs
@@ -43,7 +43,7 @@ impl<'cursor> AssetTrait for RawWriter<'cursor> {
         CustomVersion::new([0u8; 16], 0)
     }
 
-    fn position(&self) -> u64 {
+    fn position(&mut self) -> u64 {
         self.cursor.position()
     }
 

--- a/unreal_asset/src/reader/raw_writer.rs
+++ b/unreal_asset/src/reader/raw_writer.rs
@@ -3,7 +3,7 @@ use std::io::{self, Cursor, Seek, Write};
 use byteorder::WriteBytesExt;
 
 use crate::containers::indexed_map::IndexedMap;
-use crate::cursor_ext::CursorExt;
+use crate::cursor_ext::WriteExt;
 use crate::custom_version::{CustomVersion, CustomVersionTrait};
 use crate::engine_version::{guess_engine_version, EngineVersion};
 use crate::object_version::{ObjectVersion, ObjectVersionUE5};

--- a/unreal_asset/src/registry/name_table_reader.rs
+++ b/unreal_asset/src/registry/name_table_reader.rs
@@ -76,7 +76,7 @@ impl<'reader, Reader: AssetReader> AssetTrait for NameTableReader<'reader, Reade
         self.reader.get_custom_version::<T>()
     }
 
-    fn position(&self) -> u64 {
+    fn position(&mut self) -> u64 {
         self.reader.position()
     }
 

--- a/unreal_asset/src/registry/name_table_writer.rs
+++ b/unreal_asset/src/registry/name_table_writer.rs
@@ -47,7 +47,7 @@ impl<'name_map, 'writer, Writer: AssetWriter> AssetTrait
         self.writer.get_custom_version::<T>()
     }
 
-    fn position(&self) -> u64 {
+    fn position(&mut self) -> u64 {
         self.writer.position()
     }
 

--- a/unreal_asset/src/unversioned/mod.rs
+++ b/unreal_asset/src/unversioned/mod.rs
@@ -5,7 +5,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
     containers::indexed_map::IndexedMap,
-    cursor_ext::CursorExt,
+    cursor_ext::ReadExt,
     error::{Error, UsmapError},
 };
 

--- a/unreal_asset/tests/ac7.rs
+++ b/unreal_asset/tests/ac7.rs
@@ -34,7 +34,10 @@ fn ac7() -> Result<(), Error> {
         let key = AC7XorKey::new(name);
         let (decrypted_data, decrypted_bulk) = ac7::decrypt(asset_data, bulk_data, key);
 
-        let mut parsed = Asset::new(decrypted_data.clone(), Some(decrypted_bulk.clone()));
+        let mut parsed = Asset::new(
+            Cursor::new(decrypted_data.clone()),
+            Some(Cursor::new(decrypted_bulk.clone())),
+        );
         parsed.set_engine_version(EngineVersion::VER_UE4_18);
 
         parsed.parse_data()?;

--- a/unreal_asset/tests/cdo_modification.rs
+++ b/unreal_asset/tests/cdo_modification.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use unreal_asset::{
     cast,
     engine_version::EngineVersion,
@@ -24,7 +26,7 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn cdo_modification() -> Result<(), Error> {
-    let mut asset = Asset::new(TEST_ASSET.to_vec(), None);
+    let mut asset = Asset::new(Cursor::new(TEST_ASSET.to_vec()), None);
     asset.set_engine_version(EngineVersion::VER_UE4_23);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/custom_serialization_structs_in_map.rs
+++ b/unreal_asset/tests/custom_serialization_structs_in_map.rs
@@ -1,5 +1,7 @@
 mod shared;
 
+use std::io::Cursor;
+
 use unreal_asset::{
     cast,
     engine_version::EngineVersion,
@@ -26,7 +28,10 @@ const ASSET_BULK_FILE: &[u8] = include_bytes!(concat!(assets_folder!(), "asset.u
 
 #[test]
 fn custom_serialization_structs_in_map() -> Result<(), Error> {
-    let mut asset = Asset::new(ASSET_FILE.to_vec(), Some(ASSET_BULK_FILE.to_vec()));
+    let mut asset = Asset::new(
+        Cursor::new(ASSET_FILE.to_vec()),
+        Some(Cursor::new(ASSET_BULK_FILE.to_vec())),
+    );
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/data_tables.rs
+++ b/unreal_asset/tests/data_tables.rs
@@ -24,7 +24,7 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn data_tables() -> Result<(), Error> {
-    let mut asset = Asset::new(TEST_ASSET.to_vec(), None);
+    let mut asset = Asset::new(Cursor::new(TEST_ASSET.to_vec()), None);
     asset.set_engine_version(EngineVersion::VER_UE4_18);
 
     asset.parse_data()?;
@@ -60,7 +60,7 @@ fn data_tables() -> Result<(), Error> {
     asset.write_data(&mut modified, None)?;
     let modified = modified.into_inner();
 
-    let mut parsed_back = Asset::new(modified.clone(), None);
+    let mut parsed_back = Asset::new(Cursor::new(modified.clone()), None);
     parsed_back.set_engine_version(EngineVersion::VER_UE4_18);
 
     parsed_back.parse_data()?;

--- a/unreal_asset/tests/duplicate_name_map_entries.rs
+++ b/unreal_asset/tests/duplicate_name_map_entries.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Cursor};
 
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
@@ -18,7 +18,10 @@ const ASSET_BULK_FILE: &[u8] = include_bytes!(concat!(assets_folder!(), "BIOME_A
 
 #[test]
 fn duplicate_name_map_entries() -> Result<(), Error> {
-    let mut asset = Asset::new(ASSET_FILE.to_vec(), Some(ASSET_BULK_FILE.to_vec()));
+    let mut asset = Asset::new(
+        Cursor::new(ASSET_FILE.to_vec()),
+        Some(Cursor::new(ASSET_BULK_FILE.to_vec())),
+    );
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/general/astroneer_prebulk.rs
+++ b/unreal_asset/tests/general/astroneer_prebulk.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
 #[path = "../shared.rs"]
@@ -23,7 +25,7 @@ const TEST_ASSETS: [&[u8]; 5] = [
 #[test]
 fn astroneer_prebulk() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(test_asset.to_vec(), None);
+        let mut asset = Asset::new(Cursor::new(test_asset.to_vec()), None);
         asset.set_engine_version(EngineVersion::VER_UE4_23);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/bloodstained.rs
+++ b/unreal_asset/tests/general/bloodstained.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
 #[path = "../shared.rs"]
@@ -27,7 +29,7 @@ const TEST_ASSETS: [&[u8]; 6] = [
 #[test]
 fn bloodstained() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(test_asset.to_vec(), None);
+        let mut asset = Asset::new(Cursor::new(test_asset.to_vec()), None);
         asset.set_engine_version(EngineVersion::VER_UE4_18);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/codevein.rs
+++ b/unreal_asset/tests/general/codevein.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
 #[path = "../shared.rs"]
@@ -20,7 +22,10 @@ const TEST_ASSETS: [(&[u8], &[u8]); 1] = [(
 #[test]
 fn codevein() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(test_asset.to_vec(), Some(asset_bulk.to_vec()));
+        let mut asset = Asset::new(
+            Cursor::new(test_asset.to_vec()),
+            Some(Cursor::new(asset_bulk.to_vec())),
+        );
         asset.set_engine_version(EngineVersion::VER_UE4_18);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/misc426.rs
+++ b/unreal_asset/tests/general/misc426.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
 #[path = "../shared.rs"]
@@ -26,7 +28,10 @@ const TEST_ASSETS: [(&[u8], &[u8]); 2] = [
 #[test]
 fn misc426() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(test_asset.to_vec(), Some(asset_bulk.to_vec()));
+        let mut asset = Asset::new(
+            Cursor::new(test_asset.to_vec()),
+            Some(Cursor::new(asset_bulk.to_vec())),
+        );
         asset.set_engine_version(EngineVersion::VER_UE4_26);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/starlit_season.rs
+++ b/unreal_asset/tests/general/starlit_season.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
 #[path = "../shared.rs"]
@@ -26,7 +28,10 @@ const TEST_ASSETS: [(&[u8], &[u8]); 1] = [(
 #[test]
 fn starlit_season() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(test_asset.to_vec(), Some(asset_bulk.to_vec()));
+        let mut asset = Asset::new(
+            Cursor::new(test_asset.to_vec()),
+            Some(Cursor::new(asset_bulk.to_vec())),
+        );
         asset.set_engine_version(EngineVersion::VER_UE4_24);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/versioned.rs
+++ b/unreal_asset/tests/general/versioned.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
 #[path = "../shared.rs"]
@@ -20,7 +22,7 @@ const TEST_ASSETS: [&[u8]; 1] = [include_bytes!(concat!(
 #[test]
 fn versioned() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(test_asset.to_vec(), None);
+        let mut asset = Asset::new(Cursor::new(test_asset.to_vec()), None);
         asset.set_engine_version(EngineVersion::UNKNOWN);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/improper_name_map_hashes.rs
+++ b/unreal_asset/tests/improper_name_map_hashes.rs
@@ -1,6 +1,6 @@
 mod shared;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Cursor};
 
 use unreal_asset::{engine_version::EngineVersion, error::Error, Asset};
 
@@ -19,7 +19,10 @@ const ASSET_BULK_FILE: &[u8] =
 
 #[test]
 fn improper_name_map_hashes() -> Result<(), Error> {
-    let mut asset = Asset::new(ASSET_FILE.to_vec(), Some(ASSET_BULK_FILE.to_vec()));
+    let mut asset = Asset::new(
+        Cursor::new(ASSET_FILE.to_vec()),
+        Some(Cursor::new(ASSET_BULK_FILE.to_vec())),
+    );
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/shared.rs
+++ b/unreal_asset/tests/shared.rs
@@ -6,7 +6,7 @@ use unreal_asset::{cast, engine_version::EngineVersion, error::Error, exports::E
 
 #[allow(dead_code)]
 pub(crate) fn verify_reparse(
-    asset: &mut Asset,
+    asset: &mut Asset<Cursor<Vec<u8>>>,
     engine_version: EngineVersion,
 ) -> Result<(), Error> {
     let mut cursor = Cursor::new(Vec::new());
@@ -17,19 +17,19 @@ pub(crate) fn verify_reparse(
     }
     asset.write_data(&mut cursor, bulk_cursor.as_mut())?;
 
-    let cursor_inner = cursor.into_inner();
+    let cursor_inner = cursor.clone().into_inner();
     {
         let mut file = File::create("C:\\Users\\Kate\\Desktop\\astro\\test_thing.uasset")?;
         file.write_all(&cursor_inner)?;
     }
 
-    let bulk_inner = bulk_cursor.map(|e| e.into_inner());
+    let bulk_inner = bulk_cursor.clone().map(|e| e.into_inner());
     if let Some(ref bulk_inner) = bulk_inner {
         let mut file = File::create("C:\\Users\\Kate\\Desktop\\astro\\test_thing.uexp")?;
         file.write_all(&bulk_inner)?;
     }
 
-    let mut reparse = Asset::new(cursor_inner, bulk_inner);
+    let mut reparse = Asset::new(cursor, bulk_cursor);
     reparse.set_engine_version(engine_version);
 
     reparse.parse_data()?;
@@ -41,7 +41,7 @@ pub(crate) fn verify_reparse(
 pub(crate) fn verify_binary_equality(
     data: &[u8],
     bulk: Option<&[u8]>,
-    asset: &mut Asset,
+    asset: &mut Asset<Cursor<Vec<u8>>>,
 ) -> Result<(), Error> {
     let mut cursor = Cursor::new(Vec::new());
 
@@ -77,7 +77,7 @@ pub(crate) fn verify_binary_equality(
 }
 
 #[allow(dead_code)]
-pub(crate) fn verify_all_exports_parsed(asset: &Asset) -> bool {
+pub(crate) fn verify_all_exports_parsed(asset: &Asset<Cursor<Vec<u8>>>) -> bool {
     for export in &asset.exports {
         if cast!(Export, RawExport, export).is_some() {
             return false;

--- a/unreal_asset/tests/unknown_properties.rs
+++ b/unreal_asset/tests/unknown_properties.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Cursor};
 
 use unreal_asset::{
     cast, engine_version::EngineVersion, error::Error, exports::ExportNormalTrait,
@@ -21,7 +21,10 @@ const TEST_BULK: &[u8] = include_bytes!(concat!(assets_folder!(), "BP_DetPack_Ch
 
 #[test]
 fn unknown_properties() -> Result<(), Error> {
-    let mut asset = Asset::new(TEST_ASSET.to_vec(), Some(TEST_BULK.to_vec()));
+    let mut asset = Asset::new(
+        Cursor::new(TEST_ASSET.to_vec()),
+        Some(Cursor::new(TEST_BULK.to_vec())),
+    );
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_modintegrator/src/handlers/ue4_23/persistent_actors.rs
+++ b/unreal_modintegrator/src/handlers/ue4_23/persistent_actors.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{self, ErrorKind};
+use std::io::{self, Cursor, ErrorKind};
 use std::path::Path;
 
 use unreal_asset::engine_version::EngineVersion;
@@ -39,7 +39,7 @@ pub fn handle_persistent_actors(
     mod_paks: &mut Vec<PakReader<File>>,
     persistent_actor_arrays: &Vec<serde_json::Value>,
 ) -> Result<(), Error> {
-    let mut level_asset = Asset::new(LEVEL_TEMPLATE_ASSET.to_vec(), None);
+    let mut level_asset = Asset::new(Cursor::new(LEVEL_TEMPLATE_ASSET.to_vec()), None);
     level_asset.set_engine_version(EngineVersion::VER_UE4_23);
     level_asset
         .parse_data()

--- a/unreal_modintegrator/src/lib.rs
+++ b/unreal_modintegrator/src/lib.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Cursor, Write};
 use std::path::{Path, PathBuf};
 
 use error::IntegrationError;
@@ -176,14 +176,14 @@ fn read_in_memory(
     uasset: Vec<u8>,
     uexp: Option<Vec<u8>>,
     engine_version: EngineVersion,
-) -> Result<Asset, Error> {
-    let mut asset = Asset::new(uasset, uexp);
+) -> Result<Asset<Cursor<Vec<u8>>>, Error> {
+    let mut asset = Asset::new(Cursor::new(uasset), uexp.map(Cursor::new));
     asset.set_engine_version(engine_version);
     asset.parse_data()?;
     Ok(asset)
 }
 
-fn bake_mod_data(asset: &mut Asset, mods: &Vec<Metadata>) -> Result<(), Error> {
+fn bake_mod_data(asset: &mut Asset<Cursor<Vec<u8>>>, mods: &Vec<Metadata>) -> Result<(), Error> {
     let data_table_export = asset
         .exports
         .iter()
@@ -311,7 +311,7 @@ fn bake_mod_data(asset: &mut Asset, mods: &Vec<Metadata>) -> Result<(), Error> {
 }
 
 fn bake_integrator_data(
-    asset: &mut Asset,
+    asset: &mut Asset<Cursor<Vec<u8>>>,
     integrator_version: String,
     refuse_mismatched_connections: bool,
 ) -> Result<(), Error> {


### PR DESCRIPTION
by leaving the reader generic, you can use a variety of types such as File or BufReader which means you don't have to load the entire file into memory and risk a vector buffer overflow