### PR TITLE
api stuff

### DIFF
--- a/unreal_asset/tests/ac7.rs
+++ b/unreal_asset/tests/ac7.rs
@@ -37,10 +37,9 @@ fn ac7() -> Result<(), Error> {
         let mut parsed = Asset::new(
             Cursor::new(decrypted_data.as_slice()),
             Some(Cursor::new(decrypted_bulk.as_slice())),
-        );
-        parsed.set_engine_version(EngineVersion::VER_UE4_18);
+            EngineVersion::VER_UE4_18,
+        )?;
 
-        parsed.parse_data()?;
         shared::verify_binary_equality(&decrypted_data, Some(&decrypted_bulk), &mut parsed)?;
         shared::verify_all_exports_parsed(&parsed);
 

--- a/unreal_asset/tests/ac7.rs
+++ b/unreal_asset/tests/ac7.rs
@@ -35,8 +35,8 @@ fn ac7() -> Result<(), Error> {
         let (decrypted_data, decrypted_bulk) = ac7::decrypt(asset_data, bulk_data, key);
 
         let mut parsed = Asset::new(
-            Cursor::new(decrypted_data.clone()),
-            Some(Cursor::new(decrypted_bulk.clone())),
+            Cursor::new(decrypted_data.as_slice()),
+            Some(Cursor::new(decrypted_bulk.as_slice())),
         );
         parsed.set_engine_version(EngineVersion::VER_UE4_18);
 

--- a/unreal_asset/tests/cdo_modification.rs
+++ b/unreal_asset/tests/cdo_modification.rs
@@ -26,7 +26,7 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn cdo_modification() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(TEST_ASSET.to_vec()), None);
+    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None);
     asset.set_engine_version(EngineVersion::VER_UE4_23);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/cdo_modification.rs
+++ b/unreal_asset/tests/cdo_modification.rs
@@ -26,10 +26,8 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn cdo_modification() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None);
-    asset.set_engine_version(EngineVersion::VER_UE4_23);
+    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None, EngineVersion::VER_UE4_23)?;
 
-    asset.parse_data()?;
     shared::verify_binary_equality(TEST_ASSET, None, &mut asset)?;
 
     let cdo_export: &mut NormalExport = asset

--- a/unreal_asset/tests/custom_serialization_structs_in_map.rs
+++ b/unreal_asset/tests/custom_serialization_structs_in_map.rs
@@ -28,10 +28,12 @@ const ASSET_BULK_FILE: &[u8] = include_bytes!(concat!(assets_folder!(), "asset.u
 
 #[test]
 fn custom_serialization_structs_in_map() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(ASSET_FILE), Some(Cursor::new(ASSET_BULK_FILE)));
-    asset.set_engine_version(EngineVersion::VER_UE4_25);
+    let mut asset = Asset::new(
+        Cursor::new(ASSET_FILE),
+        Some(Cursor::new(ASSET_BULK_FILE)),
+        EngineVersion::VER_UE4_25,
+    )?;
 
-    asset.parse_data()?;
     shared::verify_binary_equality(ASSET_FILE, Some(ASSET_BULK_FILE), &mut asset)?;
 
     let export_two = asset

--- a/unreal_asset/tests/custom_serialization_structs_in_map.rs
+++ b/unreal_asset/tests/custom_serialization_structs_in_map.rs
@@ -28,10 +28,7 @@ const ASSET_BULK_FILE: &[u8] = include_bytes!(concat!(assets_folder!(), "asset.u
 
 #[test]
 fn custom_serialization_structs_in_map() -> Result<(), Error> {
-    let mut asset = Asset::new(
-        Cursor::new(ASSET_FILE.to_vec()),
-        Some(Cursor::new(ASSET_BULK_FILE.to_vec())),
-    );
+    let mut asset = Asset::new(Cursor::new(ASSET_FILE), Some(Cursor::new(ASSET_BULK_FILE)));
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/data_tables.rs
+++ b/unreal_asset/tests/data_tables.rs
@@ -24,10 +24,8 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn data_tables() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None);
-    asset.set_engine_version(EngineVersion::VER_UE4_18);
+    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None, EngineVersion::VER_UE4_18)?;
 
-    asset.parse_data()?;
     shared::verify_binary_equality(TEST_ASSET, None, &mut asset)?;
     assert!(shared::verify_all_exports_parsed(&asset));
 
@@ -57,10 +55,12 @@ fn data_tables() -> Result<(), Error> {
     asset.write_data(&mut modified, None)?;
     let modified = modified.into_inner();
 
-    let mut parsed_back = Asset::new(Cursor::new(modified.as_slice()), None);
-    parsed_back.set_engine_version(EngineVersion::VER_UE4_18);
+    let parsed_back = Asset::new(
+        Cursor::new(modified.as_slice()),
+        None,
+        EngineVersion::VER_UE4_18,
+    )?;
 
-    parsed_back.parse_data()?;
     shared::verify_binary_equality(&modified, None, &mut asset)?;
     assert!(shared::verify_all_exports_parsed(&parsed_back));
     assert!(parsed_back.exports.len() == 1);

--- a/unreal_asset/tests/data_tables.rs
+++ b/unreal_asset/tests/data_tables.rs
@@ -24,7 +24,7 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn data_tables() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(TEST_ASSET.to_vec()), None);
+    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None);
     asset.set_engine_version(EngineVersion::VER_UE4_18);
 
     asset.parse_data()?;
@@ -57,7 +57,7 @@ fn data_tables() -> Result<(), Error> {
     asset.write_data(&mut modified, None)?;
     let modified = modified.into_inner();
 
-    let mut parsed_back = Asset::new(Cursor::new(modified.clone()), None);
+    let mut parsed_back = Asset::new(Cursor::new(modified.as_slice()), None);
     parsed_back.set_engine_version(EngineVersion::VER_UE4_18);
 
     parsed_back.parse_data()?;

--- a/unreal_asset/tests/duplicate_name_map_entries.rs
+++ b/unreal_asset/tests/duplicate_name_map_entries.rs
@@ -18,10 +18,11 @@ const ASSET_BULK_FILE: &[u8] = include_bytes!(concat!(assets_folder!(), "BIOME_A
 
 #[test]
 fn duplicate_name_map_entries() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(ASSET_FILE), Some(Cursor::new(ASSET_BULK_FILE)));
-    asset.set_engine_version(EngineVersion::VER_UE4_25);
-
-    asset.parse_data()?;
+    let asset = Asset::new(
+        Cursor::new(ASSET_FILE),
+        Some(Cursor::new(ASSET_BULK_FILE)),
+        EngineVersion::VER_UE4_25,
+    )?;
 
     let mut has_duplicates = false;
 

--- a/unreal_asset/tests/duplicate_name_map_entries.rs
+++ b/unreal_asset/tests/duplicate_name_map_entries.rs
@@ -18,10 +18,7 @@ const ASSET_BULK_FILE: &[u8] = include_bytes!(concat!(assets_folder!(), "BIOME_A
 
 #[test]
 fn duplicate_name_map_entries() -> Result<(), Error> {
-    let mut asset = Asset::new(
-        Cursor::new(ASSET_FILE.to_vec()),
-        Some(Cursor::new(ASSET_BULK_FILE.to_vec())),
-    );
+    let mut asset = Asset::new(Cursor::new(ASSET_FILE), Some(Cursor::new(ASSET_BULK_FILE)));
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/general/astroneer_prebulk.rs
+++ b/unreal_asset/tests/general/astroneer_prebulk.rs
@@ -26,7 +26,7 @@ const TEST_ASSETS: [&[u8]; 5] = [
 #[test]
 fn astroneer_prebulk() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset.to_vec()), None);
+        let mut asset = Asset::new(Cursor::new(test_asset), None);
         asset.set_engine_version(EngineVersion::VER_UE4_23);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/astroneer_prebulk.rs
+++ b/unreal_asset/tests/general/astroneer_prebulk.rs
@@ -26,10 +26,7 @@ const TEST_ASSETS: [&[u8]; 5] = [
 #[test]
 fn astroneer_prebulk() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), None);
-        asset.set_engine_version(EngineVersion::VER_UE4_23);
-
-        asset.parse_data()?;
+        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::VER_UE4_23)?;
         shared::verify_binary_equality(test_asset, None, &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/bloodstained.rs
+++ b/unreal_asset/tests/general/bloodstained.rs
@@ -30,10 +30,7 @@ const TEST_ASSETS: [&[u8]; 6] = [
 #[test]
 fn bloodstained() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), None);
-        asset.set_engine_version(EngineVersion::VER_UE4_18);
-
-        asset.parse_data()?;
+        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::VER_UE4_18)?;
         shared::verify_binary_equality(test_asset, None, &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/bloodstained.rs
+++ b/unreal_asset/tests/general/bloodstained.rs
@@ -30,7 +30,7 @@ const TEST_ASSETS: [&[u8]; 6] = [
 #[test]
 fn bloodstained() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset.to_vec()), None);
+        let mut asset = Asset::new(Cursor::new(test_asset), None);
         asset.set_engine_version(EngineVersion::VER_UE4_18);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/codevein.rs
+++ b/unreal_asset/tests/general/codevein.rs
@@ -23,10 +23,11 @@ const TEST_ASSETS: [(&[u8], &[u8]); 1] = [(
 #[test]
 fn codevein() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), Some(Cursor::new(asset_bulk)));
-        asset.set_engine_version(EngineVersion::VER_UE4_18);
-
-        asset.parse_data()?;
+        let mut asset = Asset::new(
+            Cursor::new(test_asset),
+            Some(Cursor::new(asset_bulk)),
+            EngineVersion::VER_UE4_18,
+        )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/codevein.rs
+++ b/unreal_asset/tests/general/codevein.rs
@@ -23,10 +23,7 @@ const TEST_ASSETS: [(&[u8], &[u8]); 1] = [(
 #[test]
 fn codevein() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(
-            Cursor::new(test_asset.to_vec()),
-            Some(Cursor::new(asset_bulk.to_vec())),
-        );
+        let mut asset = Asset::new(Cursor::new(test_asset), Some(Cursor::new(asset_bulk)));
         asset.set_engine_version(EngineVersion::VER_UE4_18);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/kismet_unicode.rs
+++ b/unreal_asset/tests/general/kismet_unicode.rs
@@ -23,10 +23,11 @@ const TEST_ASSETS: [(&[u8], &[u8]); 1] = [(
 #[test]
 fn kismet_unicode() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), Some(Cursor::new(asset_bulk)));
-        asset.set_engine_version(EngineVersion::VER_UE4_25);
-        asset.parse_data()?;
-
+        let mut asset = Asset::new(
+            Cursor::new(test_asset),
+            Some(Cursor::new(asset_bulk)),
+            EngineVersion::VER_UE4_25,
+        )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
     }
 

--- a/unreal_asset/tests/general/misc426.rs
+++ b/unreal_asset/tests/general/misc426.rs
@@ -29,10 +29,11 @@ const TEST_ASSETS: [(&[u8], &[u8]); 2] = [
 #[test]
 fn misc426() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), Some(Cursor::new(asset_bulk)));
-        asset.set_engine_version(EngineVersion::VER_UE4_26);
-
-        asset.parse_data()?;
+        let mut asset = Asset::new(
+            Cursor::new(test_asset),
+            Some(Cursor::new(asset_bulk)),
+            EngineVersion::VER_UE4_26,
+        )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/misc426.rs
+++ b/unreal_asset/tests/general/misc426.rs
@@ -29,10 +29,7 @@ const TEST_ASSETS: [(&[u8], &[u8]); 2] = [
 #[test]
 fn misc426() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(
-            Cursor::new(test_asset.to_vec()),
-            Some(Cursor::new(asset_bulk.to_vec())),
-        );
+        let mut asset = Asset::new(Cursor::new(test_asset), Some(Cursor::new(asset_bulk)));
         asset.set_engine_version(EngineVersion::VER_UE4_26);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/starlit_season.rs
+++ b/unreal_asset/tests/general/starlit_season.rs
@@ -29,10 +29,11 @@ const TEST_ASSETS: [(&[u8], &[u8]); 1] = [(
 #[test]
 fn starlit_season() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), Some(Cursor::new(asset_bulk)));
-        asset.set_engine_version(EngineVersion::VER_UE4_24);
-
-        asset.parse_data()?;
+        let mut asset = Asset::new(
+            Cursor::new(test_asset),
+            Some(Cursor::new(asset_bulk)),
+            EngineVersion::VER_UE4_24,
+        )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/starlit_season.rs
+++ b/unreal_asset/tests/general/starlit_season.rs
@@ -29,10 +29,7 @@ const TEST_ASSETS: [(&[u8], &[u8]); 1] = [(
 #[test]
 fn starlit_season() -> Result<(), Error> {
     for (test_asset, asset_bulk) in TEST_ASSETS {
-        let mut asset = Asset::new(
-            Cursor::new(test_asset.to_vec()),
-            Some(Cursor::new(asset_bulk.to_vec())),
-        );
+        let mut asset = Asset::new(Cursor::new(test_asset), Some(Cursor::new(asset_bulk)));
         asset.set_engine_version(EngineVersion::VER_UE4_24);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/general/versioned.rs
+++ b/unreal_asset/tests/general/versioned.rs
@@ -23,10 +23,7 @@ const TEST_ASSETS: [&[u8]; 1] = [include_bytes!(concat!(
 #[test]
 fn versioned() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), None);
-        asset.set_engine_version(EngineVersion::UNKNOWN);
-
-        asset.parse_data()?;
+        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::UNKNOWN)?;
         shared::verify_binary_equality(test_asset, None, &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/versioned.rs
+++ b/unreal_asset/tests/general/versioned.rs
@@ -23,7 +23,7 @@ const TEST_ASSETS: [&[u8]; 1] = [include_bytes!(concat!(
 #[test]
 fn versioned() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset.to_vec()), None);
+        let mut asset = Asset::new(Cursor::new(test_asset), None);
         asset.set_engine_version(EngineVersion::UNKNOWN);
 
         asset.parse_data()?;

--- a/unreal_asset/tests/improper_name_map_hashes.rs
+++ b/unreal_asset/tests/improper_name_map_hashes.rs
@@ -19,10 +19,7 @@ const ASSET_BULK_FILE: &[u8] =
 
 #[test]
 fn improper_name_map_hashes() -> Result<(), Error> {
-    let mut asset = Asset::new(
-        Cursor::new(ASSET_FILE.to_vec()),
-        Some(Cursor::new(ASSET_BULK_FILE.to_vec())),
-    );
+    let mut asset = Asset::new(Cursor::new(ASSET_FILE), Some(Cursor::new(ASSET_BULK_FILE)));
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_asset/tests/improper_name_map_hashes.rs
+++ b/unreal_asset/tests/improper_name_map_hashes.rs
@@ -19,10 +19,12 @@ const ASSET_BULK_FILE: &[u8] =
 
 #[test]
 fn improper_name_map_hashes() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(ASSET_FILE), Some(Cursor::new(ASSET_BULK_FILE)));
-    asset.set_engine_version(EngineVersion::VER_UE4_25);
+    let mut asset = Asset::new(
+        Cursor::new(ASSET_FILE),
+        Some(Cursor::new(ASSET_BULK_FILE)),
+        EngineVersion::VER_UE4_25,
+    )?;
 
-    asset.parse_data()?;
     shared::verify_binary_equality(ASSET_FILE, Some(ASSET_BULK_FILE), &mut asset)?;
 
     let mut testing_entries = HashMap::from([

--- a/unreal_asset/tests/shared.rs
+++ b/unreal_asset/tests/shared.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Seek};
+use std::io::Cursor;
 
 use unreal_asset::{cast, engine_version::EngineVersion, error::Error, exports::Export, Asset};
 
@@ -21,10 +21,10 @@ pub(crate) fn verify_reparse(
 }
 
 #[allow(dead_code)]
-pub(crate) fn verify_binary_equality<C: Read + Seek>(
+pub(crate) fn verify_binary_equality(
     data: &[u8],
     bulk: Option<&[u8]>,
-    asset: &mut Asset<C>,
+    asset: &mut Asset<Cursor<&[u8]>>,
 ) -> Result<(), Error> {
     let mut cursor = Cursor::new(Vec::new());
 

--- a/unreal_asset/tests/shared.rs
+++ b/unreal_asset/tests/shared.rs
@@ -15,10 +15,7 @@ pub(crate) fn verify_reparse(
     }
     asset.write_data(&mut cursor, bulk_cursor.as_mut())?;
 
-    let mut reparse = Asset::new(cursor, bulk_cursor);
-    reparse.set_engine_version(engine_version);
-
-    reparse.parse_data()?;
+    Asset::new(cursor, bulk_cursor, engine_version)?;
 
     Ok(())
 }

--- a/unreal_asset/tests/shared.rs
+++ b/unreal_asset/tests/shared.rs
@@ -55,7 +55,7 @@ pub(crate) fn verify_binary_equality<C: Read + Seek>(
 }
 
 #[allow(dead_code)]
-pub(crate) fn verify_all_exports_parsed(asset: &Asset<Cursor<Vec<u8>>>) -> bool {
+pub(crate) fn verify_all_exports_parsed(asset: &Asset<Cursor<&[u8]>>) -> bool {
     for export in &asset.exports {
         if cast!(Export, RawExport, export).is_some() {
             return false;

--- a/unreal_asset/tests/unknown_properties.rs
+++ b/unreal_asset/tests/unknown_properties.rs
@@ -21,10 +21,11 @@ const TEST_BULK: &[u8] = include_bytes!(concat!(assets_folder!(), "BP_DetPack_Ch
 
 #[test]
 fn unknown_properties() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(TEST_ASSET), Some(Cursor::new(TEST_BULK)));
-    asset.set_engine_version(EngineVersion::VER_UE4_25);
-
-    asset.parse_data()?;
+    let mut asset = Asset::new(
+        Cursor::new(TEST_ASSET),
+        Some(Cursor::new(TEST_BULK)),
+        EngineVersion::VER_UE4_25,
+    )?;
     shared::verify_binary_equality(TEST_ASSET, Some(TEST_BULK), &mut asset)?;
     assert!(shared::verify_all_exports_parsed(&asset));
 

--- a/unreal_asset/tests/unknown_properties.rs
+++ b/unreal_asset/tests/unknown_properties.rs
@@ -21,10 +21,7 @@ const TEST_BULK: &[u8] = include_bytes!(concat!(assets_folder!(), "BP_DetPack_Ch
 
 #[test]
 fn unknown_properties() -> Result<(), Error> {
-    let mut asset = Asset::new(
-        Cursor::new(TEST_ASSET.to_vec()),
-        Some(Cursor::new(TEST_BULK.to_vec())),
-    );
+    let mut asset = Asset::new(Cursor::new(TEST_ASSET), Some(Cursor::new(TEST_BULK)));
     asset.set_engine_version(EngineVersion::VER_UE4_25);
 
     asset.parse_data()?;

--- a/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
+++ b/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
@@ -39,11 +39,12 @@ pub fn handle_persistent_actors(
     mod_paks: &mut Vec<PakReader<File>>,
     persistent_actor_arrays: &Vec<serde_json::Value>,
 ) -> Result<(), Error> {
-    let mut level_asset = Asset::new(Cursor::new(LEVEL_TEMPLATE_ASSET.to_vec()), None);
-    level_asset.set_engine_version(EngineVersion::VER_UE4_23);
-    level_asset
-        .parse_data()
-        .map_err(|e| io::Error::new(ErrorKind::Other, e.to_string()))?;
+    let mut level_asset = Asset::new(
+        Cursor::new(LEVEL_TEMPLATE_ASSET),
+        None,
+        EngineVersion::VER_UE4_23,
+    )
+    .map_err(|e| io::Error::new(ErrorKind::Other, e.to_string()))?;
 
     let actor_template = cast!(Export, NormalExport, level_asset.exports[2].clone())
         .ok_or_else(|| io::Error::new(ErrorKind::Other, "Corrupted actor_template"))?;

--- a/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
+++ b/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
@@ -39,7 +39,7 @@ pub fn handle_persistent_actors(
     mod_paks: &mut Vec<PakReader<File>>,
     persistent_actor_arrays: &Vec<serde_json::Value>,
 ) -> Result<(), Error> {
-    let mut level_asset = Asset::new(
+    let level_asset = Asset::new(
         Cursor::new(LEVEL_TEMPLATE_ASSET),
         None,
         EngineVersion::VER_UE4_23,

--- a/unreal_mod_integrator/src/helpers.rs
+++ b/unreal_mod_integrator/src/helpers.rs
@@ -95,9 +95,9 @@ where
     )?)
 }
 
-pub fn write_asset(
+pub fn write_asset<C: std::io::Read + std::io::Seek>(
     pak: &mut PakMemory,
-    asset: &Asset<Cursor<&[u8]>>,
+    asset: &Asset<C>,
     name: &String,
 ) -> Result<(), Error> {
     let mut uasset_cursor = Cursor::new(Vec::new());

--- a/unreal_mod_integrator/src/helpers.rs
+++ b/unreal_mod_integrator/src/helpers.rs
@@ -88,15 +88,16 @@ where
     )?;
     let uasset = read_fn(name)?.ok_or_else(|| IntegrationError::asset_not_found(name.clone()))?;
 
-    let mut asset = Asset::new(Cursor::new(uasset), uexp.map(Cursor::new));
-    asset.set_engine_version(engine_version);
-    asset.parse_data()?;
-    Ok(asset)
+    Ok(Asset::new(
+        Cursor::new(uasset),
+        uexp.map(Cursor::new),
+        engine_version,
+    )?)
 }
 
 pub fn write_asset(
     pak: &mut PakMemory,
-    asset: &Asset<Cursor<Vec<u8>>>,
+    asset: &Asset<Cursor<&[u8]>>,
     name: &String,
 ) -> Result<(), Error> {
     let mut uasset_cursor = Cursor::new(Vec::new());


### PR DESCRIPTION
# Changes
- updated the tests which are public examples of the api to have no unnecessary memory allocations (it's best to avoid vecs and just use slices where possible)
- merged the whole `Asset::new`->`set_engine_version`->`parse_data` thing together  into `Asset::new` since literally every program using unreal_asset will do this
- updated the tests and the integrator to use this