### PR TITLE
no strings

### DIFF
--- a/unreal_asset/src/asset/mod.rs
+++ b/unreal_asset/src/asset/mod.rs
@@ -309,7 +309,7 @@ pub trait AssetTrait {
     fn add_name_reference(&mut self, name: String, force_add_duplicates: bool) -> i32;
 
     /// Get a name reference by an FName map index
-    fn get_name_reference(&self, index: i32) -> String;
+    fn get_name_reference(&self, index: i32) -> &str;
 
     /// Add an `FName`
     fn add_fname(&mut self, slice: &str) -> FName;
@@ -352,7 +352,7 @@ pub trait ExportReaderTrait: ArchiveReader + AssetTrait + Sized {
         let mut new_map_value_overrides = IndexedMap::new();
         let new_array_overrides = IndexedMap::new();
 
-        let mut export: Export = match export_class_type.get_content().as_str() {
+        let mut export: Export = match export_class_type.get_content() {
             "Level" => LevelExport::from_base(&base_export, self, next_starting)?.into(),
             "StringTable" => StringTableExport::from_base(&base_export, self)?.into(),
             "Enum" | "UserDefinedEnum" => EnumExport::from_base(&base_export, self)?.into(),
@@ -375,15 +375,17 @@ pub trait ExportReaderTrait: ArchiveReader + AssetTrait + Sized {
                                     match struct_property.struct_value.is_import() {
                                         true => self
                                             .get_import(struct_property.struct_value)
-                                            .map(|e| e.object_name.get_content()),
+                                            .map(|e| e.object_name.get_content().to_string()),
                                         false => None,
                                     }
                                 }
                                 _ => None,
                             };
                             if let Some(key) = key_override {
-                                new_map_key_overrides
-                                    .insert(map.generic_property.name.get_content(), key);
+                                new_map_key_overrides.insert(
+                                    map.generic_property.name.get_content().to_string(),
+                                    key,
+                                );
                             }
 
                             let value_override = match &*map.value_prop {
@@ -391,7 +393,7 @@ pub trait ExportReaderTrait: ArchiveReader + AssetTrait + Sized {
                                     match struct_property.struct_value.is_import() {
                                         true => self
                                             .get_import(struct_property.struct_value)
-                                            .map(|e| e.object_name.get_content()),
+                                            .map(|e| e.object_name.get_content().to_string()),
                                         false => None,
                                     }
                                 }
@@ -399,8 +401,10 @@ pub trait ExportReaderTrait: ArchiveReader + AssetTrait + Sized {
                             };
 
                             if let Some(value) = value_override {
-                                new_map_value_overrides
-                                    .insert(map.generic_property.name.get_content(), value);
+                                new_map_value_overrides.insert(
+                                    map.generic_property.name.get_content().to_string(),
+                                    value,
+                                );
                             }
                         }
                     }

--- a/unreal_asset/src/asset/mod.rs
+++ b/unreal_asset/src/asset/mod.rs
@@ -301,15 +301,15 @@ pub trait AssetTrait {
     /// Gets the name map
     fn get_name_map(&self) -> SharedResource<NameMap>;
 
-    // todo: hese methods probably should be replaced with getters to name map
+    // todo: these methods probably should be replaced with getters to name map
     /// Search an FName reference
     fn search_name_reference(&self, name: &str) -> Option<i32>;
 
     /// Add an FName reference
     fn add_name_reference(&mut self, name: String, force_add_duplicates: bool) -> i32;
 
-    /// Get a name reference by an FName map index
-    fn get_name_reference(&self, index: i32) -> &str;
+    /// Get a name reference by an FName map index and do something with it
+    fn get_name_reference<T>(&self, index: i32, func: impl FnOnce(&str) -> T) -> T;
 
     /// Add an `FName`
     fn add_fname(&mut self, slice: &str) -> FName;
@@ -352,70 +352,67 @@ pub trait ExportReaderTrait: ArchiveReader + AssetTrait + Sized {
         let mut new_map_value_overrides = IndexedMap::new();
         let new_array_overrides = IndexedMap::new();
 
-        let mut export: Export = match export_class_type.get_content() {
-            "Level" => LevelExport::from_base(&base_export, self, next_starting)?.into(),
-            "StringTable" => StringTableExport::from_base(&base_export, self)?.into(),
-            "Enum" | "UserDefinedEnum" => EnumExport::from_base(&base_export, self)?.into(),
-            "Function" => FunctionExport::from_base(&base_export, self)?.into(),
-            _ => {
-                if export_class_type.get_content().ends_with("DataTable") {
-                    DataTableExport::from_base(&base_export, self)?.into()
-                } else if export_class_type.get_content().ends_with("StringTable") {
-                    StringTableExport::from_base(&base_export, self)?.into()
-                } else if export_class_type
-                    .get_content()
-                    .ends_with("BlueprintGeneratedClass")
-                {
-                    let class_export = ClassExport::from_base(&base_export, self)?;
+        let mut export: Export = export_class_type.get_content(|class| {
+            Ok::<Export, Error>(match class {
+                "Level" => LevelExport::from_base(&base_export, self, next_starting)?.into(),
+                "StringTable" => StringTableExport::from_base(&base_export, self)?.into(),
+                "Enum" | "UserDefinedEnum" => EnumExport::from_base(&base_export, self)?.into(),
+                "Function" => FunctionExport::from_base(&base_export, self)?.into(),
+                _ => {
+                    if export_class_type.ends_with("DataTable") {
+                        DataTableExport::from_base(&base_export, self)?.into()
+                    } else if export_class_type.ends_with("StringTable") {
+                        StringTableExport::from_base(&base_export, self)?.into()
+                    } else if export_class_type.ends_with("BlueprintGeneratedClass") {
+                        let class_export = ClassExport::from_base(&base_export, self)?;
 
-                    for entry in &class_export.struct_export.loaded_properties {
-                        if let FProperty::FMapProperty(map) = entry {
-                            let key_override = match &*map.key_prop {
-                                FProperty::FStructProperty(struct_property) => {
-                                    match struct_property.struct_value.is_import() {
-                                        true => self
-                                            .get_import(struct_property.struct_value)
-                                            .map(|e| e.object_name.get_content().to_string()),
-                                        false => None,
+                        for entry in &class_export.struct_export.loaded_properties {
+                            if let FProperty::FMapProperty(map) = entry {
+                                let key_override = match &*map.key_prop {
+                                    FProperty::FStructProperty(struct_property) => {
+                                        match struct_property.struct_value.is_import() {
+                                            true => self
+                                                .get_import(struct_property.struct_value)
+                                                .map(|e| e.object_name.get_owned_content()),
+                                            false => None,
+                                        }
                                     }
+                                    _ => None,
+                                };
+                                if let Some(key) = key_override {
+                                    new_map_key_overrides
+                                        .insert(map.generic_property.name.get_owned_content(), key);
                                 }
-                                _ => None,
-                            };
-                            if let Some(key) = key_override {
-                                new_map_key_overrides.insert(
-                                    map.generic_property.name.get_content().to_string(),
-                                    key,
-                                );
-                            }
 
-                            let value_override = match &*map.value_prop {
-                                FProperty::FStructProperty(struct_property) => {
-                                    match struct_property.struct_value.is_import() {
-                                        true => self
-                                            .get_import(struct_property.struct_value)
-                                            .map(|e| e.object_name.get_content().to_string()),
-                                        false => None,
+                                let value_override = match &*map.value_prop {
+                                    FProperty::FStructProperty(struct_property) => {
+                                        match struct_property.struct_value.is_import() {
+                                            true => self
+                                                .get_import(struct_property.struct_value)
+                                                .map(|e| e.object_name.get_owned_content()),
+                                            false => None,
+                                        }
                                     }
-                                }
-                                _ => None,
-                            };
+                                    _ => None,
+                                };
 
-                            if let Some(value) = value_override {
-                                new_map_value_overrides.insert(
-                                    map.generic_property.name.get_content().to_string(),
-                                    value,
-                                );
+                                if let Some(value) = value_override {
+                                    new_map_value_overrides.insert(
+                                        map.generic_property.name.get_owned_content(),
+                                        value,
+                                    );
+                                }
                             }
                         }
+                        class_export.into()
+                    } else if export_class_type.ends_with("Property") {
+                        PropertyExport::from_base(&base_export, self)?.into()
+                    } else {
+                        NormalExport::from_base(&base_export, self)?.into()
                     }
-                    class_export.into()
-                } else if export_class_type.get_content().ends_with("Property") {
-                    PropertyExport::from_base(&base_export, self)?.into()
-                } else {
-                    NormalExport::from_base(&base_export, self)?.into()
                 }
-            }
-        };
+            })
+        })?;
 
         let extras_len = next_starting as i64 - self.position() as i64;
         if extras_len < 0 {

--- a/unreal_asset/src/asset/name_map.rs
+++ b/unreal_asset/src/asset/name_map.rs
@@ -82,12 +82,12 @@ impl NameMap {
     pub fn get_name_reference(&self, index: i32) -> &str {
         // to avoid the panic this could return an option instead
 
-        // if index < 0 {
-        //     return (-index).to_string(); // is this right even?
-        // }
-        // if index >= self.name_map_index_list.len() as i32 {
-        //     return index.to_string();
-        // }
+        if index < 0 {
+            return "error: name reference index too low";
+        }
+        if index >= self.name_map_index_list.len() as i32 {
+            return "error: name reference index too high";
+        }
         &self.name_map_index_list[index as usize]
     }
 

--- a/unreal_asset/src/asset/name_map.rs
+++ b/unreal_asset/src/asset/name_map.rs
@@ -91,6 +91,11 @@ impl NameMap {
         &self.name_map_index_list[index as usize]
     }
 
+    /// Get a name reference by an FName map index as a `String`
+    pub fn get_owned_name(&self, index: i32) -> String {
+        self.get_name_reference(index).to_string()
+    }
+
     /// Get a mutable name reference by an FName map index
     pub fn get_name_reference_mut(&mut self, index: i32) -> &mut String {
         &mut self.name_map_index_list[index as usize]

--- a/unreal_asset/src/asset/name_map.rs
+++ b/unreal_asset/src/asset/name_map.rs
@@ -10,7 +10,7 @@ use crate::{
         indexed_map::IndexedMap,
         shared_resource::{CyclicSharedResource, SharedResource, SharedResourceWeakRef},
     },
-    types::fname::{FName, EMappedNameType},
+    types::fname::{EMappedNameType, FName},
 };
 
 /// Asset name map
@@ -79,14 +79,16 @@ impl NameMap {
     }
 
     /// Get a name reference by an FName map index
-    pub fn get_name_reference(&self, index: i32) -> String {
-        if index < 0 {
-            return (-index).to_string(); // is this right even?
-        }
-        if index >= self.name_map_index_list.len() as i32 {
-            return index.to_string();
-        }
-        self.name_map_index_list[index as usize].to_owned()
+    pub fn get_name_reference(&self, index: i32) -> &str {
+        // to avoid the panic this could return an option instead
+
+        // if index < 0 {
+        //     return (-index).to_string(); // is this right even?
+        // }
+        // if index >= self.name_map_index_list.len() as i32 {
+        //     return index.to_string();
+        // }
+        &self.name_map_index_list[index as usize]
     }
 
     /// Get a mutable name reference by an FName map index

--- a/unreal_asset/src/error.rs
+++ b/unreal_asset/src/error.rs
@@ -147,7 +147,7 @@ impl PropertyError {
             ancestry
                 .ancestry
                 .iter()
-                .map(|e| e.get_content())
+                .map(|e| e.get_owned_content())
                 .collect::<Vec<_>>()
                 .join("/")
                 .into_boxed_str(),
@@ -166,7 +166,7 @@ impl PropertyError {
             ancestry
                 .ancestry
                 .iter()
-                .map(|e| e.get_content())
+                .map(|e| e.get_owned_content())
                 .collect::<Vec<_>>()
                 .join("/")
                 .into_boxed_str(),

--- a/unreal_asset/src/exports/data_table_export.rs
+++ b/unreal_asset/src/exports/data_table_export.rs
@@ -50,7 +50,7 @@ impl DataTableExport {
         let mut decided_struct_type = FName::from_slice("Generic");
         for data in &normal_export.properties {
             if let Property::ObjectProperty(property) = data {
-                if property.name.is("RowStruct") && property.value.is_import() {
+                if property.name == "RowStruct" && property.value.is_import() {
                     if let Some(import) = asset.get_import(property.value) {
                         decided_struct_type = import.object_name.clone();
                     }
@@ -96,7 +96,7 @@ impl ExportTrait for DataTableExport {
 
         let mut decided_struct_type = FName::from_slice("Generic");
         for data in &self.normal_export.properties {
-            if data.get_name().is("RowStruct") {
+            if data.get_name() == "RowStruct" {
                 if let Property::ObjectProperty(prop) = data {
                     if let Some(import) = asset.get_import(prop.value) {
                         decided_struct_type = import.object_name;

--- a/unreal_asset/src/exports/data_table_export.rs
+++ b/unreal_asset/src/exports/data_table_export.rs
@@ -50,8 +50,7 @@ impl DataTableExport {
         let mut decided_struct_type = FName::from_slice("Generic");
         for data in &normal_export.properties {
             if let Property::ObjectProperty(property) = data {
-                if property.name.get_content().as_str() == "RowStruct" && property.value.is_import()
-                {
+                if property.name.get_content() == "RowStruct" && property.value.is_import() {
                     if let Some(import) = asset.get_import(property.value) {
                         decided_struct_type = import.object_name.clone();
                     }
@@ -97,7 +96,7 @@ impl ExportTrait for DataTableExport {
 
         let mut decided_struct_type = FName::from_slice("Generic");
         for data in &self.normal_export.properties {
-            if data.get_name().get_content().as_str() == "RowStruct" {
+            if data.get_name().get_content() == "RowStruct" {
                 if let Property::ObjectProperty(prop) = data {
                     if let Some(import) = asset.get_import(prop.value) {
                         decided_struct_type = import.object_name;

--- a/unreal_asset/src/exports/data_table_export.rs
+++ b/unreal_asset/src/exports/data_table_export.rs
@@ -50,7 +50,7 @@ impl DataTableExport {
         let mut decided_struct_type = FName::from_slice("Generic");
         for data in &normal_export.properties {
             if let Property::ObjectProperty(property) = data {
-                if property.name.get_content() == "RowStruct" && property.value.is_import() {
+                if property.name.is("RowStruct") && property.value.is_import() {
                     if let Some(import) = asset.get_import(property.value) {
                         decided_struct_type = import.object_name.clone();
                     }
@@ -96,7 +96,7 @@ impl ExportTrait for DataTableExport {
 
         let mut decided_struct_type = FName::from_slice("Generic");
         for data in &self.normal_export.properties {
-            if data.get_name().get_content() == "RowStruct" {
+            if data.get_name().is("RowStruct") {
                 if let Property::ObjectProperty(prop) = data {
                     if let Some(import) = asset.get_import(prop.value) {
                         decided_struct_type = import.object_name;

--- a/unreal_asset/src/fproperty.rs
+++ b/unreal_asset/src/fproperty.rs
@@ -184,7 +184,7 @@ impl FProperty {
     /// Read an `FProperty` from an asset
     pub fn new<Reader: ArchiveReader>(asset: &mut Reader) -> Result<Self, Error> {
         let serialized_type = asset.read_fname()?;
-        let res: FProperty = match serialized_type.get_content().as_str() {
+        let res: FProperty = match serialized_type.get_content() {
             "EnumProperty" => FEnumProperty::new(asset)?.into(),
             "ArrayProperty" => FArrayProperty::new(asset)?.into(),
             "SetProperty" => FSetProperty::new(asset)?.into(),
@@ -250,7 +250,8 @@ impl ToSerializedName for FProperty {
                 .serialized_type
                 .as_ref()
                 .map(|e| e.get_content())
-                .unwrap_or_else(|| String::from("Generic")),
+                .unwrap_or("Generic")
+                .to_string(),
         }
     }
 }

--- a/unreal_asset/src/fproperty.rs
+++ b/unreal_asset/src/fproperty.rs
@@ -184,29 +184,30 @@ impl FProperty {
     /// Read an `FProperty` from an asset
     pub fn new<Reader: ArchiveReader>(asset: &mut Reader) -> Result<Self, Error> {
         let serialized_type = asset.read_fname()?;
-        let res: FProperty = match serialized_type.get_content() {
-            "EnumProperty" => FEnumProperty::new(asset)?.into(),
-            "ArrayProperty" => FArrayProperty::new(asset)?.into(),
-            "SetProperty" => FSetProperty::new(asset)?.into(),
-            "ObjectProperty" => FObjectProperty::new(asset)?.into(),
-            "SoftObjectProperty" => FSoftObjectProperty::new(asset)?.into(),
-            "ClassProperty" => FClassProperty::new(asset)?.into(),
-            "SoftClassProperty" => FSoftClassProperty::new(asset)?.into(),
-            "DelegateProperty" => FDelegateProperty::new(asset)?.into(),
-            "MulticastDelegateProperty" => FMulticastDelegateProperty::new(asset)?.into(),
-            "MulticastInlineDelegateProperty" => {
-                FMulticastInlineDelegateProperty::new(asset)?.into()
-            }
-            "InterfaceProperty" => FInterfaceProperty::new(asset)?.into(),
-            "MapProperty" => FMapProperty::new(asset)?.into(),
-            "BoolProperty" => FBoolProperty::new(asset)?.into(),
-            "ByteProperty" => FByteProperty::new(asset)?.into(),
-            "StructProperty" => FStructProperty::new(asset)?.into(),
-            "NumericProperty" => FNumericProperty::new(asset)?.into(),
-            _ => FGenericProperty::with_serialized_type(asset, Some(serialized_type))?.into(),
-        };
-
-        Ok(res)
+        serialized_type.get_content(|ty| {
+            Ok::<FProperty, Error>(match ty {
+                "EnumProperty" => FEnumProperty::new(asset)?.into(),
+                "ArrayProperty" => FArrayProperty::new(asset)?.into(),
+                "SetProperty" => FSetProperty::new(asset)?.into(),
+                "ObjectProperty" => FObjectProperty::new(asset)?.into(),
+                "SoftObjectProperty" => FSoftObjectProperty::new(asset)?.into(),
+                "ClassProperty" => FClassProperty::new(asset)?.into(),
+                "SoftClassProperty" => FSoftClassProperty::new(asset)?.into(),
+                "DelegateProperty" => FDelegateProperty::new(asset)?.into(),
+                "MulticastDelegateProperty" => FMulticastDelegateProperty::new(asset)?.into(),
+                "MulticastInlineDelegateProperty" => {
+                    FMulticastInlineDelegateProperty::new(asset)?.into()
+                }
+                "InterfaceProperty" => FInterfaceProperty::new(asset)?.into(),
+                "MapProperty" => FMapProperty::new(asset)?.into(),
+                "BoolProperty" => FBoolProperty::new(asset)?.into(),
+                "ByteProperty" => FByteProperty::new(asset)?.into(),
+                "StructProperty" => FStructProperty::new(asset)?.into(),
+                "NumericProperty" => FNumericProperty::new(asset)?.into(),
+                _ => FGenericProperty::with_serialized_type(asset, Some(serialized_type.clone()))?
+                    .into(),
+            })
+        })
     }
 
     /// Write an `FProperty` to an asset
@@ -249,9 +250,8 @@ impl ToSerializedName for FProperty {
             FProperty::FGenericProperty(generic) => generic
                 .serialized_type
                 .as_ref()
-                .map(|e| e.get_content())
-                .unwrap_or("Generic")
-                .to_string(),
+                .map(|e| e.get_owned_content())
+                .unwrap_or("Generic".to_string()),
         }
     }
 }

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -618,8 +618,8 @@ impl<'a, C: Read + Seek> Asset<C> {
     }
 
     /// Get a name reference by an FName map index
-    pub fn get_name_reference(&self, index: i32) -> &str {
-        self.name_map.get_ref().get_name_reference(index)
+    pub fn get_name_reference<T>(&self, index: i32, func: impl FnOnce(&str) -> T) -> T {
+        func(self.name_map.get_ref().get_name_reference(index))
     }
 
     /// Add an `FName`
@@ -992,7 +992,7 @@ impl<'a, C: Read + Seek> Asset<C> {
     pub fn rebuild_name_map(&mut self) {
         let mut current_name_map = self.name_map.clone();
         self.traverse_fnames(&mut |mut name| {
-            let content = name.get_content().to_string();
+            let content = name.get_owned_content();
             let FName::Backed { index, name_map, .. } = &mut name else {
                 return;
             };
@@ -1311,8 +1311,8 @@ impl<C: Read + Seek> AssetTrait for Asset<C> {
             .add_name_reference(name, force_add_duplicates)
     }
 
-    fn get_name_reference(&self, index: i32) -> &str {
-        self.name_map.get_ref().get_name_reference(index)
+    fn get_name_reference<T>(&self, index: i32, func: impl FnOnce(&str) -> T) -> T {
+        func(self.name_map.get_ref().get_name_reference(index))
     }
 
     fn add_fname(&mut self, slice: &str) -> FName {

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -1000,7 +1000,7 @@ impl<'a, C: Read + Seek> Asset<C> {
             if *name_map != current_name_map {
                 let new_index = current_name_map
                     .get_mut()
-                    .add_name_reference(content.to_string(), false);
+                    .add_name_reference(content, false);
 
                 *index = new_index;
                 *name_map = current_name_map.clone();

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -618,7 +618,7 @@ impl<'a, C: Read + Seek> Asset<C> {
     }
 
     /// Get a name reference by an FName map index
-    pub fn get_name_reference(&self, index: i32) -> String {
+    pub fn get_name_reference(&self, index: i32) -> &str {
         self.name_map.get_ref().get_name_reference(index)
     }
 
@@ -992,15 +992,15 @@ impl<'a, C: Read + Seek> Asset<C> {
     pub fn rebuild_name_map(&mut self) {
         let mut current_name_map = self.name_map.clone();
         self.traverse_fnames(&mut |mut name| {
-            let content = name.get_content();
-            let FName::Backed { index, number: _, ty: _, name_map } = &mut name else {
+            let content = name.get_content().to_string();
+            let FName::Backed { index, name_map, .. } = &mut name else {
                 return;
             };
 
             if *name_map != current_name_map {
                 let new_index = current_name_map
                     .get_mut()
-                    .add_name_reference(content, false);
+                    .add_name_reference(content.to_string(), false);
 
                 *index = new_index;
                 *name_map = current_name_map.clone();
@@ -1311,7 +1311,7 @@ impl<C: Read + Seek> AssetTrait for Asset<C> {
             .add_name_reference(name, force_add_duplicates)
     }
 
-    fn get_name_reference(&self, index: i32) -> String {
+    fn get_name_reference(&self, index: i32) -> &str {
         self.name_map.get_ref().get_name_reference(index)
     }
 

--- a/unreal_asset/src/properties/array_property.rs
+++ b/unreal_asset/src/properties/array_property.rs
@@ -129,25 +129,24 @@ impl ArrayProperty {
         }
 
         if asset.has_unversioned_properties() && array_type.is_none() {
-            return Err(PropertyError::no_type(&name.get_content(), &ancestry).into());
+            return Err(PropertyError::no_type(name.get_content(), &ancestry).into());
         }
 
         let new_ancestry = ancestry.with_parent(name.clone());
 
-        if (array_type.is_some()
-            && array_type.as_ref().unwrap().get_content().as_str() == "StructProperty")
+        if (array_type.is_some() && array_type.as_ref().unwrap().get_content() == "StructProperty")
             && serialize_struct_differently
             && !asset.has_unversioned_properties()
         {
             let mut full_type = FName::from_slice("Generic");
             if asset.get_object_version() >= ObjectVersion::VER_UE4_INNER_ARRAY_TAG_INFO {
                 name = asset.read_fname()?;
-                if &name.get_content() == "None" {
+                if name.get_content() == "None" {
                     return Ok(ArrayProperty::default());
                 }
 
                 let this_array_type = asset.read_fname()?;
-                if &this_array_type.get_content() == "None" {
+                if this_array_type.get_content() == "None" {
                     return Ok(ArrayProperty::default());
                 }
 
@@ -168,7 +167,7 @@ impl ArrayProperty {
                 asset.read_property_guid()?;
             } else if let Some(type_override) = asset
                 .get_array_struct_type_override()
-                .get_by_key(&name.get_content())
+                .get_by_key(name.get_content())
                 .cloned()
             {
                 full_type = asset.add_fname(&type_override);
@@ -270,8 +269,7 @@ impl ArrayProperty {
         let begin = asset.position();
         asset.write_i32::<LE>(self.value.len() as i32)?;
 
-        if (array_type.is_some()
-            && array_type.as_ref().unwrap().get_content().as_str() == "StructProperty")
+        if (array_type.is_some() && array_type.as_ref().unwrap().get_content() == "StructProperty")
             && serialize_structs_differently
         {
             let property: &StructProperty = match !self.value.is_empty() {

--- a/unreal_asset/src/properties/array_property.rs
+++ b/unreal_asset/src/properties/array_property.rs
@@ -134,21 +134,19 @@ impl ArrayProperty {
 
         let new_ancestry = ancestry.with_parent(name.clone());
 
-        if array_type
-            .as_ref()
-            .is_some_and(|ty| ty.is("StructProperty"))
+        if array_type.as_ref().is_some_and(|ty| ty == "StructProperty")
             && serialize_struct_differently
             && !asset.has_unversioned_properties()
         {
             let mut full_type = FName::from_slice("Generic");
             if asset.get_object_version() >= ObjectVersion::VER_UE4_INNER_ARRAY_TAG_INFO {
                 name = asset.read_fname()?;
-                if name.is("None") {
+                if name == "None" {
                     return Ok(ArrayProperty::default());
                 }
 
                 let this_array_type = asset.read_fname()?;
-                if this_array_type.is("None") {
+                if this_array_type == "None" {
                     return Ok(ArrayProperty::default());
                 }
 
@@ -206,7 +204,7 @@ impl ArrayProperty {
                 .as_ref()
                 .ok_or_else(|| Error::invalid_file("Unknown array type".to_string()))?;
             for i in 0..num_entries {
-                let entry: Property = if array_type.is("StructProperty") {
+                let entry: Property = if array_type == "StructProperty" {
                     let struct_type = match array_struct_type {
                         Some(ref e) => Some(e.clone()),
                         None => Some(FName::from_slice("Generic")),
@@ -274,9 +272,7 @@ impl ArrayProperty {
         let begin = asset.position();
         asset.write_i32::<LE>(self.value.len() as i32)?;
 
-        if array_type
-            .as_ref()
-            .is_some_and(|ty| ty.is("StructProperty"))
+        if array_type.as_ref().is_some_and(|ty| ty == "StructProperty")
             && serialize_structs_differently
         {
             let property: &StructProperty = match !self.value.is_empty() {

--- a/unreal_asset/src/properties/array_property.rs
+++ b/unreal_asset/src/properties/array_property.rs
@@ -129,34 +129,40 @@ impl ArrayProperty {
         }
 
         if asset.has_unversioned_properties() && array_type.is_none() {
-            return Err(PropertyError::no_type(name.get_content(), &ancestry).into());
+            return name.get_content(|name| Err(PropertyError::no_type(name, &ancestry).into()));
         }
 
         let new_ancestry = ancestry.with_parent(name.clone());
 
-        if (array_type.is_some() && array_type.as_ref().unwrap().get_content() == "StructProperty")
+        if array_type
+            .as_ref()
+            .is_some_and(|ty| ty.is("StructProperty"))
             && serialize_struct_differently
             && !asset.has_unversioned_properties()
         {
             let mut full_type = FName::from_slice("Generic");
             if asset.get_object_version() >= ObjectVersion::VER_UE4_INNER_ARRAY_TAG_INFO {
                 name = asset.read_fname()?;
-                if name.get_content() == "None" {
+                if name.is("None") {
                     return Ok(ArrayProperty::default());
                 }
 
                 let this_array_type = asset.read_fname()?;
-                if this_array_type.get_content() == "None" {
+                if this_array_type.is("None") {
                     return Ok(ArrayProperty::default());
                 }
 
-                if this_array_type.get_content() != array_type.as_ref().unwrap().get_content() {
-                    return Err(Error::invalid_file(format!(
-                        "Invalid array type {} vs {}",
-                        this_array_type.get_content(),
-                        array_type.as_ref().unwrap().get_content()
-                    )));
-                }
+                this_array_type.get_content(|this_array_type| {
+                    array_type.as_ref().unwrap().get_content(|array_type| {
+                        if this_array_type != array_type {
+                            return Err(Error::invalid_file(format!(
+                                "Invalid array type {} vs {}",
+                                this_array_type, array_type
+                            )));
+                        }
+                        Ok(())
+                    })
+                })?;
 
                 struct_length = asset.read_i64::<LE>()?;
                 full_type = asset.read_fname()?;
@@ -165,9 +171,8 @@ impl ArrayProperty {
                 asset.read_exact(&mut guid)?;
                 struct_guid = Some(guid);
                 asset.read_property_guid()?;
-            } else if let Some(type_override) = asset
-                .get_array_struct_type_override()
-                .get_by_key(name.get_content())
+            } else if let Some(type_override) = name
+                .get_content(|name| asset.get_array_struct_type_override().get_by_key(name))
                 .cloned()
             {
                 full_type = asset.add_fname(&type_override);
@@ -201,7 +206,7 @@ impl ArrayProperty {
                 .as_ref()
                 .ok_or_else(|| Error::invalid_file("Unknown array type".to_string()))?;
             for i in 0..num_entries {
-                let entry: Property = if array_type.get_content() == "StructProperty" {
+                let entry: Property = if array_type.is("StructProperty") {
                     let struct_type = match array_struct_type {
                         Some(ref e) => Some(e.clone()),
                         None => Some(FName::from_slice("Generic")),
@@ -269,7 +274,9 @@ impl ArrayProperty {
         let begin = asset.position();
         asset.write_i32::<LE>(self.value.len() as i32)?;
 
-        if (array_type.is_some() && array_type.as_ref().unwrap().get_content() == "StructProperty")
+        if array_type
+            .as_ref()
+            .is_some_and(|ty| ty.is("StructProperty"))
             && serialize_structs_differently
         {
             let property: &StructProperty = match !self.value.is_empty() {

--- a/unreal_asset/src/properties/enum_property.rs
+++ b/unreal_asset/src/properties/enum_property.rs
@@ -60,11 +60,11 @@ impl EnumProperty {
                         .get_mappings()
                         .unwrap()
                         .enum_map
-                        .get_by_key(&enum_ty.get_content())
+                        .get_by_key(enum_ty.get_content())
                         .ok_or_else(|| {
                             Error::invalid_file(
                                 "Missing unversioned info for: ".to_string()
-                                    + &enum_ty.get_content(),
+                                    + enum_ty.get_content(),
                             )
                         })?;
                     let value = match enum_index == u8::MAX {
@@ -134,7 +134,7 @@ impl PropertyTrait for EnumProperty {
                 .get_mappings()
                 .ok_or_else(PropertyError::no_mappings)?
                 .enum_map
-                .get_by_key(&enum_type)
+                .get_by_key(enum_type)
                 .ok_or_else(|| {
                     Error::invalid_file("Missing unversioned info for: ".to_string() + &enum_type)
                 })?;

--- a/unreal_asset/src/properties/enum_property.rs
+++ b/unreal_asset/src/properties/enum_property.rs
@@ -54,7 +54,7 @@ impl EnumProperty {
                 let inner_ty =
                     FName::new_dummy(enum_data.inner_property.get_property_type().to_string(), 0);
 
-                if inner_ty.is("ByteProperty") {
+                if inner_ty == "ByteProperty" {
                     let enum_index = asset.read_u8()?;
                     let info = enum_ty
                         .get_content(|ty| asset.get_mappings().unwrap().enum_map.get_by_key(ty))
@@ -115,7 +115,7 @@ impl PropertyTrait for EnumProperty {
             && self
                 .inner_type
                 .as_ref()
-                .map(|e| e.is("ByteProperty"))
+                .map(|e| e == "ByteProperty")
                 .unwrap_or(false)
         {
             self.enum_type
@@ -139,7 +139,7 @@ impl PropertyTrait for EnumProperty {
                         Some(value) => info
                             .iter()
                             .enumerate()
-                            .find(|(_, e)| value.is(*e))
+                            .find(|(_, e)| value == *e)
                             .map(|(index, _)| index as u8)
                             .ok_or_else(|| {
                                 Error::invalid_file(

--- a/unreal_asset/src/properties/enum_property.rs
+++ b/unreal_asset/src/properties/enum_property.rs
@@ -131,7 +131,7 @@ impl PropertyTrait for EnumProperty {
                         .get_by_key(enum_type)
                         .ok_or_else(|| {
                             Error::invalid_file(
-                                "Missing unversioned info for: ".to_string() + &enum_type,
+                                "Missing unversioned info for: ".to_string() + enum_type,
                             )
                         })?;
 
@@ -143,7 +143,7 @@ impl PropertyTrait for EnumProperty {
                             .map(|(index, _)| index as u8)
                             .ok_or_else(|| {
                                 Error::invalid_file(
-                                    "Missing unversioned info for: ".to_string() + &enum_type,
+                                    "Missing unversioned info for: ".to_string() + enum_type,
                                 )
                             })?,
                         None => u8::MAX,

--- a/unreal_asset/src/properties/enum_property.rs
+++ b/unreal_asset/src/properties/enum_property.rs
@@ -54,18 +54,14 @@ impl EnumProperty {
                 let inner_ty =
                     FName::new_dummy(enum_data.inner_property.get_property_type().to_string(), 0);
 
-                if inner_ty.get_content() == "ByteProperty" {
+                if inner_ty.is("ByteProperty") {
                     let enum_index = asset.read_u8()?;
-                    let info = asset
-                        .get_mappings()
-                        .unwrap()
-                        .enum_map
-                        .get_by_key(enum_ty.get_content())
+                    let info = enum_ty
+                        .get_content(|ty| asset.get_mappings().unwrap().enum_map.get_by_key(ty))
                         .ok_or_else(|| {
-                            Error::invalid_file(
-                                "Missing unversioned info for: ".to_string()
-                                    + enum_ty.get_content(),
-                            )
+                            Error::invalid_file(enum_ty.get_content(|ty| {
+                                "Missing unversioned info for: ".to_string() + ty
+                            }))
                         })?;
                     let value = match enum_index == u8::MAX {
                         true => None,
@@ -119,41 +115,43 @@ impl PropertyTrait for EnumProperty {
             && self
                 .inner_type
                 .as_ref()
-                .map(|e| e.get_content() == "ByteProperty")
+                .map(|e| e.is("ByteProperty"))
                 .unwrap_or(false)
         {
-            let enum_type = self
-                .enum_type
+            self.enum_type
                 .as_ref()
                 .ok_or_else(|| {
                     Error::no_data("enum_type is None on an unversioned property".to_string())
                 })?
-                .get_content();
+                .get_content(|enum_type| {
+                    let info = asset
+                        .get_mappings()
+                        .ok_or_else(PropertyError::no_mappings)?
+                        .enum_map
+                        .get_by_key(enum_type)
+                        .ok_or_else(|| {
+                            Error::invalid_file(
+                                "Missing unversioned info for: ".to_string() + &enum_type,
+                            )
+                        })?;
 
-            let info = asset
-                .get_mappings()
-                .ok_or_else(PropertyError::no_mappings)?
-                .enum_map
-                .get_by_key(enum_type)
-                .ok_or_else(|| {
-                    Error::invalid_file("Missing unversioned info for: ".to_string() + &enum_type)
+                    let enum_index = match self.value.as_ref() {
+                        Some(value) => info
+                            .iter()
+                            .enumerate()
+                            .find(|(_, e)| value.is(*e))
+                            .map(|(index, _)| index as u8)
+                            .ok_or_else(|| {
+                                Error::invalid_file(
+                                    "Missing unversioned info for: ".to_string() + &enum_type,
+                                )
+                            })?,
+                        None => u8::MAX,
+                    };
+
+                    asset.write_u8(enum_index)?;
+                    Ok::<(), Error>(())
                 })?;
-
-            let enum_index = match self.value.as_ref() {
-                Some(value) => info
-                    .iter()
-                    .enumerate()
-                    .find(|(_, e)| **e == value.get_content())
-                    .map(|(index, _)| index as u8)
-                    .ok_or_else(|| {
-                        Error::invalid_file(
-                            "Missing unversioned info for: ".to_string() + &enum_type,
-                        )
-                    })?,
-                None => u8::MAX,
-            };
-
-            asset.write_u8(enum_index)?;
             return Ok(size_of::<u8>());
         }
 

--- a/unreal_asset/src/properties/int_property.rs
+++ b/unreal_asset/src/properties/int_property.rs
@@ -324,7 +324,7 @@ impl ByteProperty {
                             .get_name_map_index_list()
                             .len() as i32
                     && name_map_index == 0
-                    && !asset.get_name_reference(name_map_index).contains('/')
+                    && !asset.get_name_reference(name_map_index, |name| name.contains('/'))
                 {
                     BytePropertyValue::FName(asset.read_fname()?)
                 } else {

--- a/unreal_asset/src/properties/map_property.rs
+++ b/unreal_asset/src/properties/map_property.rs
@@ -64,7 +64,7 @@ impl MapProperty {
         is_key: bool,
     ) -> Result<Property, Error> {
         let new_ancestry = ancestry.with_parent(name.clone());
-        match type_name.get_content().as_str() {
+        match type_name.get_content() {
             "StructProperty" => {
                 let mut struct_type = None;
 
@@ -92,11 +92,11 @@ impl MapProperty {
                     .or_else(|| match is_key {
                         true => asset
                             .get_map_key_override()
-                            .get_by_key(&name.get_content())
+                            .get_by_key(name.get_content())
                             .map(|s| FName::new_dummy(s.to_owned(), 0)),
                         false => asset
                             .get_map_value_override()
-                            .get_by_key(&name.get_content())
+                            .get_by_key(name.get_content())
                             .map(|s| FName::new_dummy(s.to_owned(), 0)),
                     })
                     .unwrap_or_else(|| FName::from_slice("Generic"));

--- a/unreal_asset/src/properties/map_property.rs
+++ b/unreal_asset/src/properties/map_property.rs
@@ -64,7 +64,7 @@ impl MapProperty {
         is_key: bool,
     ) -> Result<Property, Error> {
         let new_ancestry = ancestry.with_parent(name.clone());
-        match type_name.get_content() {
+        type_name.get_content(|ty| match ty {
             "StructProperty" => {
                 let mut struct_type = None;
 
@@ -89,15 +89,17 @@ impl MapProperty {
                 }
 
                 let struct_type = struct_type
-                    .or_else(|| match is_key {
-                        true => asset
-                            .get_map_key_override()
-                            .get_by_key(name.get_content())
-                            .map(|s| FName::new_dummy(s.to_owned(), 0)),
-                        false => asset
-                            .get_map_value_override()
-                            .get_by_key(name.get_content())
-                            .map(|s| FName::new_dummy(s.to_owned(), 0)),
+                    .or_else(|| {
+                        name.get_content(|name| match is_key {
+                            true => asset
+                                .get_map_key_override()
+                                .get_by_key(name)
+                                .map(|s| FName::new_dummy(s.to_owned(), 0)),
+                            false => asset
+                                .get_map_value_override()
+                                .get_by_key(name)
+                                .map(|s| FName::new_dummy(s.to_owned(), 0)),
+                        })
                     })
                     .unwrap_or_else(|| FName::from_slice("Generic"));
 
@@ -124,7 +126,7 @@ impl MapProperty {
                 0,
                 false,
             ),
-        }
+        })
     }
 
     /// Read a `MapProperty` from an asset

--- a/unreal_asset/src/properties/mod.rs
+++ b/unreal_asset/src/properties/mod.rs
@@ -497,15 +497,14 @@ impl Property {
             }
 
             let mut practicing_unversioned_property_index = header.unversioned_property_index;
-            let mut schema = mappings
-                .schemas
-                .get_by_key(parent_name.get_content())
-                .ok_or_else(|| {
+            let mut schema = parent_name.get_content(|name| {
+                mappings.schemas.get_by_key(name).ok_or_else(|| {
                     PropertyError::no_schema(
-                        parent_name.get_content().to_string(),
+                        name.to_string(),
                         practicing_unversioned_property_index,
                     )
-                })?;
+                })
+            })?;
 
             while practicing_unversioned_property_index >= schema.prop_count as usize {
                 practicing_unversioned_property_index -= schema.prop_count as usize;
@@ -516,7 +515,7 @@ impl Property {
                         .get_by_key(&schema.super_type)
                         .ok_or_else(|| {
                             PropertyError::no_schema(
-                                parent_name.get_content().to_string(),
+                                parent_name.get_owned_content(),
                                 practicing_unversioned_property_index,
                             )
                         })?;
@@ -547,7 +546,7 @@ impl Property {
             }
         } else {
             name = asset.read_fname()?;
-            if name.get_content() == "None" {
+            if name.is("None") {
                 return Ok(None);
             }
 
@@ -587,301 +586,9 @@ impl Property {
             return Ok(EmptyProperty::new(type_name.clone(), name, ancestry).into());
         }
 
-        let res = match type_name.get_content() {
-            "BoolProperty" => BoolProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "UInt16Property" => UInt16Property::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "UInt32Property" => UInt32Property::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "UInt64Property" => UInt64Property::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "FloatProperty" => FloatProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "Int16Property" => Int16Property::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "Int64Property" => Int64Property::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "Int8Property" => Int8Property::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "IntProperty" => IntProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "ByteProperty" => ByteProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                fallback_length,
-                duplication_index,
-            )?
-            .into(),
-            "DoubleProperty" => DoubleProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-
-            "NameProperty" => {
-                NameProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-            "StrProperty" => {
-                StrProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-            "TextProperty" => {
-                TextProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-
-            "ObjectProperty" => {
-                ObjectProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "AssetObjectProperty" => {
-                AssetObjectProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "SoftObjectProperty" => {
-                SoftObjectProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-
-            "IntPoint" => {
-                IntPointProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "Vector" => {
-                VectorProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "Vector4" => {
-                Vector4Property::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "Vector2D" => {
-                Vector2DProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "Box" => {
-                BoxProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-            "Box2D" => {
-                Box2DProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-            "Quat" => {
-                QuatProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-            "Rotator" => {
-                RotatorProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "Plane" => {
-                PlaneProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-            "LinearColor" => {
-                LinearColorProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "Color" => {
-                ColorProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-            "Timespan" => {
-                TimeSpanProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "DateTime" => {
-                DateTimeProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "Guid" => {
-                GuidProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-
-            "SetProperty" => SetProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "ArrayProperty" => ArrayProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-                true,
-            )?
-            .into(),
-            "MapProperty" => {
-                MapProperty::new(asset, name, ancestry, include_header, duplication_index)?.into()
-            }
-
-            "PerPlatformBool" => PerPlatformBoolProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "PerPlatformInt" => PerPlatformIntProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "PerPlatformFloat" => PerPlatformFloatProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-
-            "MaterialAttributesInput" => MaterialAttributesInputProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "ExpressionInput" => ExpressionInputProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "ColorMaterialInput" => ColorMaterialInputProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "ScalarMaterialInput" => ScalarMaterialInputProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "ShadingModelMaterialInput" => ShadingModelMaterialInputProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "VectorMaterialInput" => VectorMaterialInputProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "Vector2MaterialInput" => Vector2MaterialInputProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-
-            "WeightedRandomSampler" => WeightedRandomSamplerProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "SkeletalMeshAreaWeightedTriangleSampler" => {
-                SkeletalMeshAreaWeightedTriangleSampler::new(
+        type_name.get_content(|ty| {
+            Ok::<Property, Error>(match ty {
+                "BoolProperty" => BoolProperty::new(
                     asset,
                     name,
                     ancestry,
@@ -889,358 +596,682 @@ impl Property {
                     length,
                     duplication_index,
                 )?
-                .into()
-            }
-            "SkeletalMeshSamplingLODBuiltData" => SkeletalMeshSamplingLODBuiltDataProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "SoftAssetPath" => SoftAssetPathProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "SoftObjectPath" => SoftObjectPathProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "SoftClassPath" => SoftClassPathProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "StringAssetReference" => StringAssetReferenceProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
+                .into(),
+                "UInt16Property" => UInt16Property::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "UInt32Property" => UInt32Property::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "UInt64Property" => UInt64Property::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "FloatProperty" => FloatProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "Int16Property" => Int16Property::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "Int64Property" => Int64Property::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "Int8Property" => Int8Property::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "IntProperty" => IntProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "ByteProperty" => ByteProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    fallback_length,
+                    duplication_index,
+                )?
+                .into(),
+                "DoubleProperty" => DoubleProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
 
-            "DelegateProperty" => DelegateProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "MulticastDelegateProperty" => MulticastDelegateProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "MulticastSparseDelegateProperty" => MulticastSparseDelegateProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "MulticastInlineDelegateProperty" => MulticastInlineDelegateProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "RichCurveKey" => RichCurveKeyProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "ViewTargetBlendParams" => ViewTargetBlendParamsProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "GameplayTagContainer" => GameplayTagContainerProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "SmartName" => SmartNameProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
+                "NameProperty" => {
+                    NameProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "StrProperty" => {
+                    StrProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "TextProperty" => {
+                    TextProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
 
-            "StructProperty" => StructProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "EnumProperty" => EnumProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "ClothLODData" => ClothLodDataProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-
-            "FontCharacter" => FontCharacterProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "UniqueNetIdRepl" => UniqueNetIdProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "NiagaraVariable" => NiagaraVariableProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "NiagaraVariableWithOffset" => NiagaraVariableWithOffsetProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "FontData" => FontDataProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-            )?
-            .into(),
-            "FloatRange" => {
-                FloatRangeProperty::new(asset, name, ancestry, include_header, duplication_index)?
-                    .into()
-            }
-            "RawStructProperty" => RawStructProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-                length,
-            )?
-            .into(),
-
-            "MovieSceneEvalTemplatePtr" => MovieSceneEvalTemplatePtrProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneTrackImplementationPtr" => MovieSceneTrackImplementationPtrProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneEvaluationFieldEntityTree" => {
-                MovieSceneEvaluationFieldEntityTreeProperty::new(
+                "ObjectProperty" => {
+                    ObjectProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "AssetObjectProperty" => AssetObjectProperty::new(
                     asset,
                     name,
                     ancestry,
                     include_header,
                     duplication_index,
                 )?
-                .into()
-            }
-            "MovieSceneSubSequenceTree" => MovieSceneSubSequenceTreeProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneSequenceInstanceDataPtr" => MovieSceneSequenceInstanceDataPtrProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "SectionEvaluationDataTree" => SectionEvaluationDataTreeProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneTrackFieldData" => MovieSceneTrackFieldDataProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneEventParameters" => MovieSceneEventParametersProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneFloatChannel" => MovieSceneFloatChannelProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneFloatValue" => MovieSceneFloatValueProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneFrameRange" => MovieSceneFrameRangeProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneSegment" => MovieSceneSegmentProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneSegmentIdentifier" => MovieSceneSegmentIdentifierProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneTrackIdentifier" => MovieSceneTrackIdentifierProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneSequenceId" => MovieSceneSequenceIdProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
-            "MovieSceneEvaluationKey" => MovieSceneEvaluationKeyProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                duplication_index,
-            )?
-            .into(),
+                .into(),
+                "SoftObjectProperty" => SoftObjectProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
 
-            _ => UnknownProperty::new(
-                asset,
-                name,
-                ancestry,
-                include_header,
-                length,
-                duplication_index,
-                type_name.clone(),
-            )?
-            .into(),
-        };
+                "IntPoint" => {
+                    IntPointProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Vector" => {
+                    VectorProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Vector4" => {
+                    Vector4Property::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Vector2D" => {
+                    Vector2DProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Box" => {
+                    BoxProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Box2D" => {
+                    Box2DProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Quat" => {
+                    QuatProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Rotator" => {
+                    RotatorProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Plane" => {
+                    PlaneProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "LinearColor" => LinearColorProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "Color" => {
+                    ColorProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Timespan" => {
+                    TimeSpanProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "DateTime" => {
+                    DateTimeProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+                "Guid" => {
+                    GuidProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
 
-        Ok(res)
+                "SetProperty" => SetProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "ArrayProperty" => ArrayProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                    true,
+                )?
+                .into(),
+                "MapProperty" => {
+                    MapProperty::new(asset, name, ancestry, include_header, duplication_index)?
+                        .into()
+                }
+
+                "PerPlatformBool" => PerPlatformBoolProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "PerPlatformInt" => PerPlatformIntProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "PerPlatformFloat" => PerPlatformFloatProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+
+                "MaterialAttributesInput" => MaterialAttributesInputProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "ExpressionInput" => ExpressionInputProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "ColorMaterialInput" => ColorMaterialInputProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "ScalarMaterialInput" => ScalarMaterialInputProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "ShadingModelMaterialInput" => ShadingModelMaterialInputProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "VectorMaterialInput" => VectorMaterialInputProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "Vector2MaterialInput" => Vector2MaterialInputProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+
+                "WeightedRandomSampler" => WeightedRandomSamplerProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "SkeletalMeshAreaWeightedTriangleSampler" => {
+                    SkeletalMeshAreaWeightedTriangleSampler::new(
+                        asset,
+                        name,
+                        ancestry,
+                        include_header,
+                        length,
+                        duplication_index,
+                    )?
+                    .into()
+                }
+                "SkeletalMeshSamplingLODBuiltData" => {
+                    SkeletalMeshSamplingLODBuiltDataProperty::new(
+                        asset,
+                        name,
+                        ancestry,
+                        include_header,
+                        length,
+                        duplication_index,
+                    )?
+                    .into()
+                }
+                "SoftAssetPath" => SoftAssetPathProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "SoftObjectPath" => SoftObjectPathProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "SoftClassPath" => SoftClassPathProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "StringAssetReference" => StringAssetReferenceProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+
+                "DelegateProperty" => DelegateProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "MulticastDelegateProperty" => MulticastDelegateProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "MulticastSparseDelegateProperty" => MulticastSparseDelegateProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "MulticastInlineDelegateProperty" => MulticastInlineDelegateProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "RichCurveKey" => RichCurveKeyProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "ViewTargetBlendParams" => ViewTargetBlendParamsProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "GameplayTagContainer" => GameplayTagContainerProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "SmartName" => SmartNameProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+
+                "StructProperty" => StructProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "EnumProperty" => EnumProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "ClothLODData" => ClothLodDataProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+
+                "FontCharacter" => FontCharacterProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "UniqueNetIdRepl" => UniqueNetIdProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "NiagaraVariable" => NiagaraVariableProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "NiagaraVariableWithOffset" => NiagaraVariableWithOffsetProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "FontData" => FontDataProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                )?
+                .into(),
+                "FloatRange" => FloatRangeProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "RawStructProperty" => RawStructProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                    length,
+                )?
+                .into(),
+
+                "MovieSceneEvalTemplatePtr" => MovieSceneEvalTemplatePtrProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneTrackImplementationPtr" => {
+                    MovieSceneTrackImplementationPtrProperty::new(
+                        asset,
+                        name,
+                        ancestry,
+                        include_header,
+                        duplication_index,
+                    )?
+                    .into()
+                }
+                "MovieSceneEvaluationFieldEntityTree" => {
+                    MovieSceneEvaluationFieldEntityTreeProperty::new(
+                        asset,
+                        name,
+                        ancestry,
+                        include_header,
+                        duplication_index,
+                    )?
+                    .into()
+                }
+                "MovieSceneSubSequenceTree" => MovieSceneSubSequenceTreeProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneSequenceInstanceDataPtr" => {
+                    MovieSceneSequenceInstanceDataPtrProperty::new(
+                        asset,
+                        name,
+                        ancestry,
+                        include_header,
+                        duplication_index,
+                    )?
+                    .into()
+                }
+                "SectionEvaluationDataTree" => SectionEvaluationDataTreeProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneTrackFieldData" => MovieSceneTrackFieldDataProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneEventParameters" => MovieSceneEventParametersProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneFloatChannel" => MovieSceneFloatChannelProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneFloatValue" => MovieSceneFloatValueProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneFrameRange" => MovieSceneFrameRangeProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneSegment" => MovieSceneSegmentProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneSegmentIdentifier" => MovieSceneSegmentIdentifierProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneTrackIdentifier" => MovieSceneTrackIdentifierProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneSequenceId" => MovieSceneSequenceIdProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+                "MovieSceneEvaluationKey" => MovieSceneEvaluationKeyProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    duplication_index,
+                )?
+                .into(),
+
+                _ => UnknownProperty::new(
+                    asset,
+                    name,
+                    ancestry,
+                    include_header,
+                    length,
+                    duplication_index,
+                    type_name.clone(),
+                )?
+                .into(),
+            })
+        })
     }
 
     /// Writes a property to an ArchiveWriter
@@ -1287,8 +1318,8 @@ macro_rules! property_inner_serialized_name {
                         Self::$inner(_) => String::from($name),
                     )*
                     Self::UnknownProperty(unk) => unk
-                        .serialized_type.get_content().to_string(),
-                    Self::EmptyProperty(empty) => empty.type_name.get_content().to_string()
+                        .serialized_type.get_owned_content(),
+                    Self::EmptyProperty(empty) => empty.type_name.get_owned_content()
                 }
             }
         }

--- a/unreal_asset/src/properties/mod.rs
+++ b/unreal_asset/src/properties/mod.rs
@@ -5,7 +5,6 @@ use std::io::SeekFrom;
 
 use byteorder::LE;
 use enum_dispatch::enum_dispatch;
-use lazy_static::lazy_static;
 use unreal_asset_proc_macro::FNameContainer;
 
 use crate::error::{Error, PropertyError};
@@ -194,67 +193,65 @@ macro_rules! impl_property_data_trait {
     };
 }
 
-lazy_static! {
-    static ref CUSTOM_SERIALIZATION: Vec<String> = Vec::from([
-        String::from("SkeletalMeshSamplingLODBuiltData"),
-        String::from("SkeletalMeshAreaWeightedTriangleSampler"),
-        String::from("SmartName"),
-        String::from("SoftObjectPath"),
-        String::from("WeightedRandomSampler"),
-        String::from("SoftClassPath"),
-        String::from("StringAssetReference"),
-        String::from("Color"),
-        String::from("ExpressionInput"),
-        String::from("MaterialAttributesInput"),
-        String::from("ColorMaterialInput"),
-        String::from("ScalarMaterialInput"),
-        String::from("ShadingModelMaterialInput"),
-        String::from("VectorMaterialInput"),
-        String::from("Vector2MaterialInput"),
-        String::from("GameplayTagContainer"),
-        String::from("PerPlatformBool"),
-        String::from("PerPlatformInt"),
-        String::from("RichCurveKey"),
-        String::from("SoftAssetPath"),
-        String::from("Timespan"),
-        String::from("DateTime"),
-        String::from("Guid"),
-        String::from("IntPoint"),
-        String::from("LinearColor"),
-        String::from("Quat"),
-        String::from("Rotator"),
-        String::from("Vector2D"),
-        String::from("Box"),
-        String::from("PerPlatformFloat"),
-        String::from("Vector4"),
-        String::from("Vector"),
-        String::from("ViewTargetBlendParams"),
-        String::from("FontCharacter"),
-        String::from("UniqueNetIdRepl"),
-        String::from("NiagaraVariable"),
-        String::from("FontData"),
-        String::from("ClothLODData"),
-        String::from("FloatRange"),
-        String::from("RawStructProperty"),
-        //
-        String::from("MovieSceneEvalTemplatePtr"),
-        String::from("MovieSceneTrackImplementationPtr"),
-        String::from("MovieSceneEvaluationFieldEntityTree"),
-        String::from("MovieSceneSubSequenceTree"),
-        String::from("MovieSceneSequenceInstanceDataPtr"),
-        String::from("SectionEvaluationDataTree"),
-        String::from("MovieSceneTrackFieldData"),
-        String::from("MovieSceneEventParameters"),
-        String::from("MovieSceneFloatChannel"),
-        String::from("MovieSceneFloatValue"),
-        String::from("MovieSceneFrameRange"),
-        String::from("MovieSceneSegment"),
-        String::from("MovieSceneSegmentIdentifier"),
-        String::from("MovieSceneTrackIdentifier"),
-        String::from("MovieSceneSequenceId"),
-        String::from("MovieSceneEvaluationKey")
-    ]);
-}
+const CUSTOM_SERIALIZATION: [&str; 56] = [
+    "SkeletalMeshSamplingLODBuiltData",
+    "SkeletalMeshAreaWeightedTriangleSampler",
+    "SmartName",
+    "SoftObjectPath",
+    "WeightedRandomSampler",
+    "SoftClassPath",
+    "StringAssetReference",
+    "Color",
+    "ExpressionInput",
+    "MaterialAttributesInput",
+    "ColorMaterialInput",
+    "ScalarMaterialInput",
+    "ShadingModelMaterialInput",
+    "VectorMaterialInput",
+    "Vector2MaterialInput",
+    "GameplayTagContainer",
+    "PerPlatformBool",
+    "PerPlatformInt",
+    "RichCurveKey",
+    "SoftAssetPath",
+    "Timespan",
+    "DateTime",
+    "Guid",
+    "IntPoint",
+    "LinearColor",
+    "Quat",
+    "Rotator",
+    "Vector2D",
+    "Box",
+    "PerPlatformFloat",
+    "Vector4",
+    "Vector",
+    "ViewTargetBlendParams",
+    "FontCharacter",
+    "UniqueNetIdRepl",
+    "NiagaraVariable",
+    "FontData",
+    "ClothLODData",
+    "FloatRange",
+    "RawStructProperty",
+    //
+    "MovieSceneEvalTemplatePtr",
+    "MovieSceneTrackImplementationPtr",
+    "MovieSceneEvaluationFieldEntityTree",
+    "MovieSceneSubSequenceTree",
+    "MovieSceneSequenceInstanceDataPtr",
+    "SectionEvaluationDataTree",
+    "MovieSceneTrackFieldData",
+    "MovieSceneEventParameters",
+    "MovieSceneFloatChannel",
+    "MovieSceneFloatValue",
+    "MovieSceneFrameRange",
+    "MovieSceneSegment",
+    "MovieSceneSegmentIdentifier",
+    "MovieSceneTrackIdentifier",
+    "MovieSceneSequenceId",
+    "MovieSceneEvaluationKey",
+];
 
 /// This must be implemented for all properties
 #[enum_dispatch]
@@ -502,10 +499,10 @@ impl Property {
             let mut practicing_unversioned_property_index = header.unversioned_property_index;
             let mut schema = mappings
                 .schemas
-                .get_by_key(&parent_name.get_content())
+                .get_by_key(parent_name.get_content())
                 .ok_or_else(|| {
                     PropertyError::no_schema(
-                        parent_name.get_content(),
+                        parent_name.get_content().to_string(),
                         practicing_unversioned_property_index,
                     )
                 })?;
@@ -519,7 +516,7 @@ impl Property {
                         .get_by_key(&schema.super_type)
                         .ok_or_else(|| {
                             PropertyError::no_schema(
-                                parent_name.get_content(),
+                                parent_name.get_content().to_string(),
                                 practicing_unversioned_property_index,
                             )
                         })?;
@@ -550,7 +547,7 @@ impl Property {
             }
         } else {
             name = asset.read_fname()?;
-            if &name.get_content() == "None" {
+            if name.get_content() == "None" {
                 return Ok(None);
             }
 
@@ -590,7 +587,7 @@ impl Property {
             return Ok(EmptyProperty::new(type_name.clone(), name, ancestry).into());
         }
 
-        let res = match type_name.get_content().as_str() {
+        let res = match type_name.get_content() {
             "BoolProperty" => BoolProperty::new(
                 asset,
                 name,
@@ -1275,8 +1272,8 @@ impl Property {
     }
 
     /// Check if a property type has custom serialization
-    pub fn has_custom_serialization(name: &String) -> bool {
-        CUSTOM_SERIALIZATION.contains(name)
+    pub fn has_custom_serialization(name: &str) -> bool {
+        CUSTOM_SERIALIZATION.contains(&name)
     }
 }
 
@@ -1290,8 +1287,8 @@ macro_rules! property_inner_serialized_name {
                         Self::$inner(_) => String::from($name),
                     )*
                     Self::UnknownProperty(unk) => unk
-                        .serialized_type.get_content(),
-                    Self::EmptyProperty(empty) => empty.type_name.get_content()
+                        .serialized_type.get_content().to_string(),
+                    Self::EmptyProperty(empty) => empty.type_name.get_content().to_string()
                 }
             }
         }

--- a/unreal_asset/src/properties/mod.rs
+++ b/unreal_asset/src/properties/mod.rs
@@ -546,7 +546,7 @@ impl Property {
             }
         } else {
             name = asset.read_fname()?;
-            if name.is("None") {
+            if name == "None" {
                 return Ok(None);
             }
 

--- a/unreal_asset/src/properties/movies/movie_scene_eval_template_ptr_property.rs
+++ b/unreal_asset/src/properties/movies/movie_scene_eval_template_ptr_property.rs
@@ -99,7 +99,7 @@ impl PropertyTrait for MovieSceneEvalTemplatePtrProperty {
         let properties = sorted_properties.as_ref().unwrap_or(&self.value);
 
         for property in properties.iter() {
-            if property.get_name().get_content() == "TypeName" {
+            if property.get_name().is("TypeName") {
                 let str_property: &StrProperty = cast!(Property, StrProperty, property)
                     .ok_or_else(|| {
                         Error::no_data("TypeName property is not StrProperty".to_string())

--- a/unreal_asset/src/properties/movies/movie_scene_eval_template_ptr_property.rs
+++ b/unreal_asset/src/properties/movies/movie_scene_eval_template_ptr_property.rs
@@ -99,7 +99,7 @@ impl PropertyTrait for MovieSceneEvalTemplatePtrProperty {
         let properties = sorted_properties.as_ref().unwrap_or(&self.value);
 
         for property in properties.iter() {
-            if property.get_name().is("TypeName") {
+            if property.get_name() == "TypeName" {
                 let str_property: &StrProperty = cast!(Property, StrProperty, property)
                     .ok_or_else(|| {
                         Error::no_data("TypeName property is not StrProperty".to_string())

--- a/unreal_asset/src/properties/movies/movie_scene_track_implementation_ptr_property.rs
+++ b/unreal_asset/src/properties/movies/movie_scene_track_implementation_ptr_property.rs
@@ -87,7 +87,7 @@ impl PropertyTrait for MovieSceneTrackImplementationPtrProperty {
         let mut had_typename = false;
 
         for property in &self.value {
-            if property.get_name().is("TypeName") {
+            if property.get_name() == "TypeName" {
                 let str_property: &StrProperty = cast!(Property, StrProperty, property)
                     .ok_or_else(|| {
                         Error::no_data("TypeName property is not StrProperty".to_string())

--- a/unreal_asset/src/properties/movies/movie_scene_track_implementation_ptr_property.rs
+++ b/unreal_asset/src/properties/movies/movie_scene_track_implementation_ptr_property.rs
@@ -87,7 +87,7 @@ impl PropertyTrait for MovieSceneTrackImplementationPtrProperty {
         let mut had_typename = false;
 
         for property in &self.value {
-            if property.get_name().get_content() == "TypeName" {
+            if property.get_name().is("TypeName") {
                 let str_property: &StrProperty = cast!(Property, StrProperty, property)
                     .ok_or_else(|| {
                         Error::no_data("TypeName property is not StrProperty".to_string())

--- a/unreal_asset/src/properties/struct_property.rs
+++ b/unreal_asset/src/properties/struct_property.rs
@@ -123,11 +123,11 @@ impl StructProperty {
         }
 
         if asset.has_unversioned_properties() && struct_type.is_none() {
-            return Err(PropertyError::no_type(&name.get_content(), &ancestry).into());
+            return Err(PropertyError::no_type(name.get_content(), &ancestry).into());
         }
 
         let mut custom_serialization = match struct_type {
-            Some(ref e) => Property::has_custom_serialization(&e.get_content()),
+            Some(ref e) => Property::has_custom_serialization(e.get_content()),
             None => false,
         };
 
@@ -135,7 +135,6 @@ impl StructProperty {
             .as_ref()
             .map(|e| e.get_content())
             .unwrap_or_default()
-            .as_str()
         {
             "FloatRange" => {
                 // FloatRange is a special case; it can either be manually serialized as two floats (TRange<float>) or as a regular struct (FFloatRange), but the first is overridden to use the same name as the second
@@ -264,7 +263,7 @@ impl StructProperty {
         }
 
         let mut has_custom_serialization = match struct_type {
-            Some(ref e) => Property::has_custom_serialization(&e.get_content()),
+            Some(ref e) => Property::has_custom_serialization(e.get_content()),
             None => false,
         };
 
@@ -308,7 +307,7 @@ impl StructProperty {
                     struct_type
                         .as_ref()
                         .map(|e| e.get_content())
-                        .unwrap_or_else(|| "Generic".to_string())
+                        .unwrap_or("Generic")
                 ))
                 .into());
             }

--- a/unreal_asset/src/properties/struct_property.rs
+++ b/unreal_asset/src/properties/struct_property.rs
@@ -113,11 +113,7 @@ impl StructProperty {
             .and_then(|e| e.get_property(&name, &ancestry))
             .and_then(|e| cast!(UsmapPropertyData, UsmapStructPropertyData, &e.property_data))
         {
-            if struct_type
-                .as_ref()
-                .map(|e| e.is("Generic"))
-                .unwrap_or(true)
-            {
+            if struct_type.as_ref().map(|e| e == "Generic").unwrap_or(true) {
                 struct_type = Some(FName::new_dummy(struct_mapping.struct_type.clone(), 0));
             }
         }
@@ -273,25 +269,25 @@ impl StructProperty {
         };
 
         if let Some(ref struct_type) = struct_type {
-            if struct_type.is("FloatRange") {
+            if struct_type == "FloatRange" {
                 has_custom_serialization = self.value.len() == 1
                     && cast!(Property, FloatRangeProperty, &self.value[0]).is_some();
             }
 
-            if struct_type.is("RichCurveKey")
+            if struct_type == "RichCurveKey"
                 && asset.get_object_version() < ObjectVersion::VER_UE4_SERIALIZE_RICH_CURVE_KEY
             {
                 has_custom_serialization = false;
             }
 
-            if struct_type.is("MovieSceneTrackIdentifier")
+            if struct_type == "MovieSceneTrackIdentifier"
                 && asset.get_custom_version::<FEditorObjectVersion>().version
                     < FEditorObjectVersion::MovieSceneMetaDataSerialization as i32
             {
                 has_custom_serialization = false;
             }
 
-            if struct_type.is("MovieSceneFloatChannel")
+            if struct_type == "MovieSceneFloatChannel"
                 && asset
                     .get_custom_version::<FSequencerObjectVersion>()
                     .version

--- a/unreal_asset/src/properties/struct_property.rs
+++ b/unreal_asset/src/properties/struct_property.rs
@@ -123,7 +123,7 @@ impl StructProperty {
         }
 
         let mut custom_serialization = match struct_type {
-            Some(ref e) => e.get_content(|e| Property::has_custom_serialization(e)),
+            Some(ref e) => e.get_content(Property::has_custom_serialization),
             None => false,
         };
 
@@ -131,7 +131,7 @@ impl StructProperty {
             .as_ref()
             .unwrap_or(&FName::from_slice(""))
             .get_content(|ty| {
-                Ok::<(), Error>(match ty {
+                match ty {
                     "FloatRange" => {
                         // FloatRange is a special case; it can either be manually serialized as two floats (TRange<float>) or as a regular struct (FFloatRange), but the first is overridden to use the same name as the second
                         // The best solution is to just check and see if the next bit is an FName or not
@@ -181,7 +181,8 @@ impl StructProperty {
                         }
                     }
                     _ => {}
-                })
+                };
+                Ok::<(), Error>(())
             })?;
 
         if length == 0 {
@@ -264,7 +265,7 @@ impl StructProperty {
         }
 
         let mut has_custom_serialization = match struct_type {
-            Some(ref e) => e.get_content(|e| Property::has_custom_serialization(e)),
+            Some(ref e) => e.get_content(Property::has_custom_serialization),
             None => false,
         };
 

--- a/unreal_asset/src/reader/archive_trait.rs
+++ b/unreal_asset/src/reader/archive_trait.rs
@@ -102,6 +102,10 @@ pub trait ArchiveTrait {
     fn get_name_reference<T>(&self, index: i32, func: impl FnOnce(&str) -> T) -> T {
         func(self.get_name_map().get_ref().get_name_reference(index))
     }
+    /// Get FName name reference by name map index as a `String`
+    fn get_name_reference_owned(&self, index: i32) -> String {
+        self.get_name_reference(index, str::to_string)
+    }
 
     /// Get struct overrides for an `ArrayProperty`
     fn get_array_struct_type_override(&self) -> &IndexedMap<String, String>;

--- a/unreal_asset/src/reader/archive_trait.rs
+++ b/unreal_asset/src/reader/archive_trait.rs
@@ -99,7 +99,7 @@ pub trait ArchiveTrait {
     /// Get FName name map
     fn get_name_map(&self) -> SharedResource<NameMap>;
     /// Get FName name reference by name map index
-    fn get_name_reference(&self, index: i32) -> String {
+    fn get_name_reference(&self, index: i32) -> &str {
         self.get_name_map().get_ref().get_name_reference(index)
     }
 

--- a/unreal_asset/src/reader/archive_trait.rs
+++ b/unreal_asset/src/reader/archive_trait.rs
@@ -102,9 +102,9 @@ pub trait ArchiveTrait {
     fn get_name_reference<T>(&self, index: i32, func: impl FnOnce(&str) -> T) -> T {
         func(self.get_name_map().get_ref().get_name_reference(index))
     }
-    /// Get FName name reference by name map index as a `String`
-    fn get_name_reference_owned(&self, index: i32) -> String {
-        self.get_name_reference(index, str::to_string)
+    /// Get FName name by name map index as a `String`
+    fn get_owned_name(&self, index: i32) -> String {
+        self.get_name_map().get_ref().get_owned_name(index)
     }
 
     /// Get struct overrides for an `ArrayProperty`

--- a/unreal_asset/src/reader/archive_trait.rs
+++ b/unreal_asset/src/reader/archive_trait.rs
@@ -98,9 +98,9 @@ pub trait ArchiveTrait {
 
     /// Get FName name map
     fn get_name_map(&self) -> SharedResource<NameMap>;
-    /// Get FName name reference by name map index
-    fn get_name_reference(&self, index: i32) -> &str {
-        self.get_name_map().get_ref().get_name_reference(index)
+    /// Get FName name reference by name map index and do something with it
+    fn get_name_reference<T>(&self, index: i32, func: impl FnOnce(&str) -> T) -> T {
+        func(self.get_name_map().get_ref().get_name_reference(index))
     }
 
     /// Get struct overrides for an `ArrayProperty`

--- a/unreal_asset/src/reader/archive_writer.rs
+++ b/unreal_asset/src/reader/archive_writer.rs
@@ -71,7 +71,7 @@ pub trait ArchiveWriter: ArchiveTrait {
                 property.get_ancestry(),
                 property.get_duplication_index() as u32,
             ) else {
-                return Err(PropertyError::no_mapping(&property.get_name().get_content(), property.get_ancestry()).into());
+                return Err(PropertyError::no_mapping(property.get_name().get_content(), property.get_ancestry()).into());
             };
 
             if matches!(property, Property::EmptyProperty(_)) {
@@ -157,9 +157,7 @@ pub trait ArchiveWriter: ArchiveTrait {
         } else {
             fragments.push(UnversionedHeaderFragment {
                 skip_num: usize::min(
-                    mappings
-                        .get_all_properties(&parent_name.get_content())
-                        .len(),
+                    mappings.get_all_properties(parent_name.get_content()).len(),
                     i8::MAX as usize,
                 ) as u8,
                 value_num: 0,

--- a/unreal_asset/src/reader/archive_writer.rs
+++ b/unreal_asset/src/reader/archive_writer.rs
@@ -71,7 +71,7 @@ pub trait ArchiveWriter: ArchiveTrait {
                 property.get_ancestry(),
                 property.get_duplication_index() as u32,
             ) else {
-                return Err(PropertyError::no_mapping(property.get_name().get_content(), property.get_ancestry()).into());
+                return property.get_name().get_content(|name| Err(PropertyError::no_mapping(name, property.get_ancestry()).into()));
             };
 
             if matches!(property, Property::EmptyProperty(_)) {
@@ -155,16 +155,14 @@ pub trait ArchiveWriter: ArchiveTrait {
                 last_num_before_fragment = end_index - 1;
             }
         } else {
-            fragments.push(UnversionedHeaderFragment {
-                skip_num: usize::min(
-                    mappings.get_all_properties(parent_name.get_content()).len(),
-                    i8::MAX as usize,
-                ) as u8,
+            fragments.push(parent_name.get_content(|name| UnversionedHeaderFragment {
+                skip_num: usize::min(mappings.get_all_properties(name).len(), i8::MAX as usize)
+                    as u8,
                 value_num: 0,
                 first_num: 0,
                 is_last: true,
                 has_zeros: false,
-            });
+            }));
         }
 
         if let Some(fragment) = fragments.last_mut() {

--- a/unreal_asset/src/types/fname.rs
+++ b/unreal_asset/src/types/fname.rs
@@ -124,11 +124,6 @@ impl FName {
         self.get_content(str::to_string)
     }
 
-    /// Checks if an `FName`'s content is the given `&str`
-    pub fn is(&self, pat: impl AsRef<str>) -> bool {
-        self.get_content(|name| name == pat.as_ref())
-    }
-
     /// Checks if an `FName`'s content ends with the given `&str`
     pub fn ends_with(&self, pat: impl AsRef<str>) -> bool {
         self.get_content(|name| name.ends_with(pat.as_ref()))
@@ -149,7 +144,7 @@ impl FName {
 
     /// Compare `FNames` based on their content
     pub fn eq_content(&self, other: &Self) -> bool {
-        self.get_content(|this| other.is(this))
+        self.get_content(|this| other == &this)
     }
 }
 
@@ -216,6 +211,23 @@ impl Default for FName {
     }
 }
 
+impl std::cmp::PartialEq<str> for FName {
+    fn eq(&self, other: &str) -> bool {
+        self.get_content(|name| name == other)
+    }
+}
+
+impl std::cmp::PartialEq<&str> for FName {
+    fn eq(&self, other: &&str) -> bool {
+        &self == other
+    }
+}
+
+impl std::cmp::PartialEq<String> for FName {
+    fn eq(&self, other: &String) -> bool {
+        self == other
+    }
+}
 /// A trait that can be implemented for structs that contain an FName
 ///
 /// This trait will be typically used to traverse the whole asset FName tree

--- a/unreal_asset/src/types/fname.rs
+++ b/unreal_asset/src/types/fname.rs
@@ -106,7 +106,7 @@ impl FName {
         FName::new_dummy(value.to_string(), 0)
     }
 
-    /// Get access to this FName's content
+    /// Get access to this `FName`'s content
     pub fn get_content<T>(&self, func: impl FnOnce(&str) -> T) -> T {
         match self {
             FName::Backed {
@@ -119,22 +119,22 @@ impl FName {
         }
     }
 
-    /// Get this FName's content as a string
+    /// Get this `FName`'s content as a `String`
     pub fn get_owned_content(&self) -> String {
         self.get_content(str::to_string)
     }
 
-    /// Checks if an FName's content is the given &str
+    /// Checks if an `FName`'s content is the given `&str`
     pub fn is(&self, pat: impl AsRef<str>) -> bool {
         self.get_content(|name| name == pat.as_ref())
     }
 
-    /// Checks if an FName's content ends with the given &str
+    /// Checks if an `FName`'s content ends with the given `&str`
     pub fn ends_with(&self, pat: impl AsRef<str>) -> bool {
         self.get_content(|name| name.ends_with(pat.as_ref()))
     }
 
-    /// Get this FName instance number
+    /// Get this `FName` instance number
     pub fn get_number(&self) -> i32 {
         match self {
             FName::Backed {
@@ -147,7 +147,7 @@ impl FName {
         }
     }
 
-    /// Compare FNames based on their content
+    /// Compare `FNames` based on their content
     pub fn eq_content(&self, other: &Self) -> bool {
         self.get_content(|this| other.is(this))
     }

--- a/unreal_asset/src/types/fname.rs
+++ b/unreal_asset/src/types/fname.rs
@@ -115,7 +115,7 @@ impl FName {
                 let name_map = name_map.get_ref();
                 func(name_map.get_name_reference(*index))
             }
-            FName::Dummy { value, .. } => func(&value),
+            FName::Dummy { value, .. } => func(value),
         }
     }
 
@@ -144,7 +144,7 @@ impl FName {
 
     /// Compare `FNames` based on their content
     pub fn eq_content(&self, other: &Self) -> bool {
-        self.get_content(|this| other == &this)
+        self.get_content(|this| other == this)
     }
 }
 
@@ -219,7 +219,7 @@ impl std::cmp::PartialEq<str> for FName {
 
 impl std::cmp::PartialEq<&str> for FName {
     fn eq(&self, other: &&str) -> bool {
-        &self == other
+        self == *other
     }
 }
 

--- a/unreal_asset/src/types/fname.rs
+++ b/unreal_asset/src/types/fname.rs
@@ -107,16 +107,12 @@ impl FName {
     }
 
     /// Get this FName content
-    pub fn get_content(&self) -> String {
-        // todo: return string ref
+    pub fn get_content(&self) -> &str {
         match self {
             FName::Backed {
-                index,
-                number: _,
-                ty: _,
-                name_map,
+                name_map, index, ..
             } => name_map.get_ref().get_name_reference(*index),
-            FName::Dummy { value, number: _ } => value.clone(),
+            FName::Dummy { value, .. } => &value,
         }
     }
 
@@ -147,7 +143,7 @@ impl FName {
                     value: _,
                     number: _,
                 },
-            ) => self.get_content().eq(&other.get_content()),
+            ) => self.get_content().eq(other.get_content()),
             (
                 FName::Dummy {
                     value: _,
@@ -159,7 +155,7 @@ impl FName {
                     ty: _,
                     name_map: _,
                 },
-            ) => self.get_content().eq(&other.get_content()),
+            ) => self.get_content().eq(other.get_content()),
             _ => self.eq(other),
         }
     }

--- a/unreal_asset/src/unversioned/mod.rs
+++ b/unreal_asset/src/unversioned/mod.rs
@@ -205,12 +205,12 @@ impl Usmap {
                 break;
             };
 
-            let Some(schema) = self.schemas.get_by_key(&schema_name) else {
+            let Some(schema) = self.schemas.get_by_key(schema_name) else {
                 break;
             };
 
             if let Some(property) =
-                schema.get_property(&property_name.get_content(), duplication_index)
+                schema.get_property(property_name.get_content(), duplication_index)
             {
                 global_index += property.schema_index as u32;
                 return Some((property, global_index));
@@ -218,7 +218,7 @@ impl Usmap {
 
             global_index += schema.prop_count as u32;
 
-            optional_schema_name = Some(schema.super_type.clone());
+            optional_schema_name = Some(&schema.super_type);
         }
 
         // this name is not an actual property name, but an array index

--- a/unreal_asset/src/unversioned/mod.rs
+++ b/unreal_asset/src/unversioned/mod.rs
@@ -197,7 +197,7 @@ impl Usmap {
         ancestry: &Ancestry,
         duplication_index: u32,
     ) -> Option<(&UsmapProperty, u32)> {
-        let mut optional_schema_name = ancestry.get_parent().map(|e| e.get_content());
+        let mut optional_schema_name = ancestry.get_parent().map(|e| e.get_owned_content());
 
         let mut global_index = 0;
         loop {
@@ -205,12 +205,12 @@ impl Usmap {
                 break;
             };
 
-            let Some(schema) = self.schemas.get_by_key(schema_name) else {
+            let Some(schema) = self.schemas.get_by_key(&schema_name) else {
                 break;
             };
 
             if let Some(property) =
-                schema.get_property(property_name.get_content(), duplication_index)
+                property_name.get_content(|name| schema.get_property(name, duplication_index))
             {
                 global_index += property.schema_index as u32;
                 return Some((property, global_index));
@@ -218,11 +218,11 @@ impl Usmap {
 
             global_index += schema.prop_count as u32;
 
-            optional_schema_name = Some(&schema.super_type);
+            optional_schema_name = Some(schema.super_type.clone());
         }
 
         // this name is not an actual property name, but an array index
-        let Ok(_) = property_name.get_content().parse::<u32>() else {
+        let Ok(_) = property_name.get_content(|name| name.parse::<u32>()) else {
             return None;
         };
 

--- a/unreal_asset/src/unversioned/properties/enum_property.rs
+++ b/unreal_asset/src/unversioned/properties/enum_property.rs
@@ -33,10 +33,7 @@ impl UsmapEnumPropertyData {
 }
 
 impl UsmapPropertyDataTrait for UsmapEnumPropertyData {
-    fn write<W: ArchiveWriter>(
-        &self,
-        asset: &mut UsmapWriter<'_, '_, W>,
-    ) -> Result<usize, Error> {
+    fn write<W: ArchiveWriter>(&self, asset: &mut UsmapWriter<'_, '_, W>) -> Result<usize, Error> {
         asset.write_u8(EPropertyType::EnumProperty as u8)?;
         let size = self.inner_property.write(asset)?;
         asset.write_name(&self.name)?;

--- a/unreal_asset/src/uproperty.rs
+++ b/unreal_asset/src/uproperty.rs
@@ -161,37 +161,39 @@ impl UProperty {
         asset: &mut Reader,
         serialized_type: FName,
     ) -> Result<Self, Error> {
-        let prop: UProperty = match serialized_type.get_content() {
-            "EnumProperty" => UEnumProperty::new(asset)?.into(),
-            "ArrayProperty" => UArrayProperty::new(asset)?.into(),
-            "SetProperty" => USetProperty::new(asset)?.into(),
-            "ObjectProperty" => UObjectProperty::new(asset)?.into(),
-            "SoftObjectProperty" => USoftObjectProperty::new(asset)?.into(),
-            "LazyObjectProperty" => ULazyObjectProperty::new(asset)?.into(),
-            "ClassProperty" => UClassProperty::new(asset)?.into(),
-            "SoftClassProperty" => USoftClassProperty::new(asset)?.into(),
-            "DelegateProperty" => UDelegateProperty::new(asset)?.into(),
-            "MulticastDelegateProperty" => UMulticastDelegateProperty::new(asset)?.into(),
-            "MulticastInlineDelegateProperty" => {
-                UMulticastInlineDelegateProperty::new(asset)?.into()
-            }
-            "InterfaceProperty" => UInterfaceProperty::new(asset)?.into(),
-            "MapProperty" => UMapProperty::new(asset)?.into(),
-            "ByteProperty" => UByteProperty::new(asset)?.into(),
-            "StructProperty" => UStructProperty::new(asset)?.into(),
-            "DoubleProperty" => UDoubleProperty::new(asset)?.into(),
-            "FloatProperty" => UFloatProperty::new(asset)?.into(),
-            "IntProperty" => UIntProperty::new(asset)?.into(),
-            "Int8Property" => UInt8Property::new(asset)?.into(),
-            "Int16Property" => UInt16Property::new(asset)?.into(),
-            "Int64Property" => UInt64Property::new(asset)?.into(),
-            "UInt8Property" => UUInt8Property::new(asset)?.into(),
-            "UInt16Property" => UUInt16Property::new(asset)?.into(),
-            "UInt64Property" => UUInt64Property::new(asset)?.into(),
-            "NameProperty" => UNameProperty::new(asset)?.into(),
-            "StrProperty" => UStrProperty::new(asset)?.into(),
-            _ => UGenericProperty::new(asset)?.into(),
-        };
+        let prop: UProperty = serialized_type.get_content(|ty| {
+            Ok::<UProperty, Error>(match ty {
+                "EnumProperty" => UEnumProperty::new(asset)?.into(),
+                "ArrayProperty" => UArrayProperty::new(asset)?.into(),
+                "SetProperty" => USetProperty::new(asset)?.into(),
+                "ObjectProperty" => UObjectProperty::new(asset)?.into(),
+                "SoftObjectProperty" => USoftObjectProperty::new(asset)?.into(),
+                "LazyObjectProperty" => ULazyObjectProperty::new(asset)?.into(),
+                "ClassProperty" => UClassProperty::new(asset)?.into(),
+                "SoftClassProperty" => USoftClassProperty::new(asset)?.into(),
+                "DelegateProperty" => UDelegateProperty::new(asset)?.into(),
+                "MulticastDelegateProperty" => UMulticastDelegateProperty::new(asset)?.into(),
+                "MulticastInlineDelegateProperty" => {
+                    UMulticastInlineDelegateProperty::new(asset)?.into()
+                }
+                "InterfaceProperty" => UInterfaceProperty::new(asset)?.into(),
+                "MapProperty" => UMapProperty::new(asset)?.into(),
+                "ByteProperty" => UByteProperty::new(asset)?.into(),
+                "StructProperty" => UStructProperty::new(asset)?.into(),
+                "DoubleProperty" => UDoubleProperty::new(asset)?.into(),
+                "FloatProperty" => UFloatProperty::new(asset)?.into(),
+                "IntProperty" => UIntProperty::new(asset)?.into(),
+                "Int8Property" => UInt8Property::new(asset)?.into(),
+                "Int16Property" => UInt16Property::new(asset)?.into(),
+                "Int64Property" => UInt64Property::new(asset)?.into(),
+                "UInt8Property" => UUInt8Property::new(asset)?.into(),
+                "UInt16Property" => UUInt16Property::new(asset)?.into(),
+                "UInt64Property" => UUInt64Property::new(asset)?.into(),
+                "NameProperty" => UNameProperty::new(asset)?.into(),
+                "StrProperty" => UStrProperty::new(asset)?.into(),
+                _ => UGenericProperty::new(asset)?.into(),
+            })
+        })?;
 
         Ok(prop)
     }

--- a/unreal_asset/src/uproperty.rs
+++ b/unreal_asset/src/uproperty.rs
@@ -161,7 +161,7 @@ impl UProperty {
         asset: &mut Reader,
         serialized_type: FName,
     ) -> Result<Self, Error> {
-        let prop: UProperty = match serialized_type.get_content().as_str() {
+        let prop: UProperty = match serialized_type.get_content() {
             "EnumProperty" => UEnumProperty::new(asset)?.into(),
             "ArrayProperty" => UArrayProperty::new(asset)?.into(),
             "SetProperty" => USetProperty::new(asset)?.into(),

--- a/unreal_asset/tests/cdo_modification.rs
+++ b/unreal_asset/tests/cdo_modification.rs
@@ -47,7 +47,7 @@ fn cdo_modification() -> Result<(), Error> {
     let pickup_actor = cdo_export
         .properties
         .iter_mut()
-        .find(|e| e.get_name().get_content() == "PickupActor")
+        .find(|e| e.get_name().is("PickupActor"))
         .expect("Failed to find PickupActor");
 
     *pickup_actor = ObjectProperty {

--- a/unreal_asset/tests/cdo_modification.rs
+++ b/unreal_asset/tests/cdo_modification.rs
@@ -47,7 +47,7 @@ fn cdo_modification() -> Result<(), Error> {
     let pickup_actor = cdo_export
         .properties
         .iter_mut()
-        .find(|e| e.get_name().is("PickupActor"))
+        .find(|e| e.get_name() == "PickupActor")
         .expect("Failed to find PickupActor");
 
     *pickup_actor = ObjectProperty {

--- a/unreal_asset/tests/custom_serialization_structs_in_map.rs
+++ b/unreal_asset/tests/custom_serialization_structs_in_map.rs
@@ -46,7 +46,7 @@ fn custom_serialization_structs_in_map() -> Result<(), Error> {
     let test_map = export_two
         .properties
         .iter()
-        .find(|e| e.get_name().is("KekWait"))
+        .find(|e| e.get_name() == "KekWait")
         .ok_or_else(|| {
             Error::invalid_file("Export doesn't contain a KekWait property".to_string())
         })?;

--- a/unreal_asset/tests/custom_serialization_structs_in_map.rs
+++ b/unreal_asset/tests/custom_serialization_structs_in_map.rs
@@ -46,7 +46,7 @@ fn custom_serialization_structs_in_map() -> Result<(), Error> {
     let test_map = export_two
         .properties
         .iter()
-        .find(|e| e.get_name().get_content() == "KekWait")
+        .find(|e| e.get_name().is("KekWait"))
         .ok_or_else(|| {
             Error::invalid_file("Export doesn't contain a KekWait property".to_string())
         })?;

--- a/unreal_asset/tests/data_tables.rs
+++ b/unreal_asset/tests/data_tables.rs
@@ -75,7 +75,7 @@ fn data_tables() -> Result<(), Error> {
         if let Some(bool_prop) = cast!(Property, BoolProperty, property) {
             assert_eq!(
                 *flipped_values
-                    .get(&bool_prop.get_name().get_content())
+                    .get(bool_prop.get_name().get_content())
                     .unwrap(),
                 bool_prop.value
             );

--- a/unreal_asset/tests/data_tables.rs
+++ b/unreal_asset/tests/data_tables.rs
@@ -39,7 +39,7 @@ fn data_tables() -> Result<(), Error> {
     let mut found_test_name = false;
     // flip all the flags for further testing
     for property in &mut first_entry.value {
-        let property_name = property.get_name().get_content();
+        let property_name = property.get_name().get_owned_content();
         if property_name == "AcceleratorANDDoubleJump" {
             found_test_name = true;
         }
@@ -74,9 +74,9 @@ fn data_tables() -> Result<(), Error> {
     for property in &first_entry.value {
         if let Some(bool_prop) = cast!(Property, BoolProperty, property) {
             assert_eq!(
-                *flipped_values
-                    .get(bool_prop.get_name().get_content())
-                    .unwrap(),
+                bool_prop
+                    .get_name()
+                    .get_content(|name| *flipped_values.get(name).unwrap()),
                 bool_prop.value
             );
         }

--- a/unreal_asset/tests/ue5.rs
+++ b/unreal_asset/tests/ue5.rs
@@ -30,7 +30,7 @@ fn ue5() -> Result<(), Error> {
             EngineVersion::VER_UE5_2,
         )?;
 
-        shared::verify_binary_equality(&asset_data, Some(&bulk_data), &mut parsed)?;
+        shared::verify_binary_equality(asset_data, Some(bulk_data), &mut parsed)?;
         shared::verify_all_exports_parsed(&parsed);
     }
 

--- a/unreal_asset/tests/unknown_properties.rs
+++ b/unreal_asset/tests/unknown_properties.rs
@@ -39,7 +39,7 @@ fn unknown_properties() -> Result<(), Error> {
             for property in &normal_export.properties {
                 if let Some(unknown_property) = cast!(Property, UnknownProperty, property) {
                     if let Some(entry) = new_unknown_properties
-                        .get_mut(unknown_property.serialized_type.get_content().as_str())
+                        .get_mut(unknown_property.serialized_type.get_content())
                     {
                         *entry = true;
                     } else {

--- a/unreal_asset/tests/unknown_properties.rs
+++ b/unreal_asset/tests/unknown_properties.rs
@@ -38,8 +38,9 @@ fn unknown_properties() -> Result<(), Error> {
         if let Some(normal_export) = export.get_normal_export() {
             for property in &normal_export.properties {
                 if let Some(unknown_property) = cast!(Property, UnknownProperty, property) {
-                    if let Some(entry) = new_unknown_properties
-                        .get_mut(unknown_property.serialized_type.get_content())
+                    if let Some(entry) = unknown_property
+                        .serialized_type
+                        .get_content(|unk| new_unknown_properties.get_mut(unk))
                     {
                         *entry = true;
                     } else {

--- a/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
+++ b/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
@@ -162,7 +162,7 @@ pub fn handle_persistent_actors(
                         let import = asset
                             .get_import(normal_export.base_export.class_index)
                             .ok_or_else(|| io::Error::new(ErrorKind::Other, "Import not found"))?;
-                        if import.object_name.is("SimpleConstructionScript") {
+                        if import.object_name == "SimpleConstructionScript" {
                             scs_location = Some(i);
                             break;
                         }
@@ -182,9 +182,9 @@ pub fn handle_persistent_actors(
                         if array_property
                             .array_type
                             .as_ref()
-                            .map(|e| e.is("ObjectProperty"))
+                            .map(|e| e == "ObjectProperty")
                             .unwrap_or(false)
-                            && array_property.name.is("AllNodes")
+                            && array_property.name == "AllNodes"
                         {
                             for value in &array_property.value {
                                 if let Some(object_property) =
@@ -212,7 +212,7 @@ pub fn handle_persistent_actors(
                                 .ok_or_else(|| {
                                 io::Error::new(ErrorKind::Other, "Import not found")
                             })?;
-                            import.object_name.is("SCS_Node")
+                            import.object_name == "SCS_Node"
                         }
                         false => false,
                     };
@@ -232,13 +232,13 @@ pub fn handle_persistent_actors(
 
                     for property in &known_category.properties {
                         property.get_name().get_content(|name| {
-                            Ok(match name {
+                            Ok::<(), Error>(match name {
                                 "InternalVariableName" => {
                                     if let Some(name_property) =
                                         cast!(Property, NameProperty, property)
                                     {
                                         new_scs.internal_variable_name =
-                                            name_property.value.get_content_owned();
+                                            name_property.value.get_owned_content();
                                     }
                                 }
                                 "ComponentClass" => {
@@ -270,7 +270,7 @@ pub fn handle_persistent_actors(
                                         if array_property
                                             .array_type
                                             .as_ref()
-                                            .map(|e| e.is("ObjectProperty"))
+                                            .map(|e| e == "ObjectProperty")
                                             .unwrap_or(false)
                                         {
                                             for value_property in &array_property.value {

--- a/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
+++ b/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
@@ -232,7 +232,7 @@ pub fn handle_persistent_actors(
 
                     for property in &known_category.properties {
                         property.get_name().get_content(|name| {
-                            Ok::<(), Error>(match name {
+                            match name {
                                 "InternalVariableName" => {
                                     if let Some(name_property) =
                                         cast!(Property, NameProperty, property)
@@ -249,16 +249,12 @@ pub fn handle_persistent_actors(
                                             .get_import(object_property.value)
                                             .ok_or_else(|| {
                                                 io::Error::new(ErrorKind::Other, "No import")
-                                            })?
-                                            .clone();
+                                            })?;
 
                                         second_import = Some(
-                                            actor_asset
-                                                .get_import(import.outer_index)
-                                                .ok_or_else(|| {
-                                                    io::Error::new(ErrorKind::Other, "No import")
-                                                })?
-                                                .clone(),
+                                            actor_asset.get_import(import.outer_index).ok_or_else(
+                                                || io::Error::new(ErrorKind::Other, "No import"),
+                                            )?,
                                         );
                                         first_import = Some(import);
                                     }
@@ -287,7 +283,8 @@ pub fn handle_persistent_actors(
                                     }
                                 }
                                 _ => {}
-                            })
+                            };
+                            Ok::<(), Error>(())
                         })?
                     }
 

--- a/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
+++ b/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
@@ -162,7 +162,7 @@ pub fn handle_persistent_actors(
                         let import = asset
                             .get_import(normal_export.base_export.class_index)
                             .ok_or_else(|| io::Error::new(ErrorKind::Other, "Import not found"))?;
-                        if import.object_name.get_content() == "SimpleConstructionScript" {
+                        if import.object_name.is("SimpleConstructionScript") {
                             scs_location = Some(i);
                             break;
                         }
@@ -182,9 +182,9 @@ pub fn handle_persistent_actors(
                         if array_property
                             .array_type
                             .as_ref()
-                            .map(|e| e.get_content() == "ObjectProperty")
+                            .map(|e| e.is("ObjectProperty"))
                             .unwrap_or(false)
-                            && array_property.name.get_content() == "AllNodes"
+                            && array_property.name.is("AllNodes")
                         {
                             for value in &array_property.value {
                                 if let Some(object_property) =
@@ -212,7 +212,7 @@ pub fn handle_persistent_actors(
                                 .ok_or_else(|| {
                                 io::Error::new(ErrorKind::Other, "Import not found")
                             })?;
-                            import.object_name.get_content() == "SCS_Node"
+                            import.object_name.is("SCS_Node")
                         }
                         false => false,
                     };
@@ -231,61 +231,64 @@ pub fn handle_persistent_actors(
                     let mut second_import = None;
 
                     for property in &known_category.properties {
-                        match property.get_name().get_content().as_str() {
-                            "InternalVariableName" => {
-                                if let Some(name_property) = cast!(Property, NameProperty, property)
-                                {
-                                    new_scs.internal_variable_name =
-                                        name_property.value.get_content();
+                        property.get_name().get_content(|name| {
+                            Ok(match name {
+                                "InternalVariableName" => {
+                                    if let Some(name_property) =
+                                        cast!(Property, NameProperty, property)
+                                    {
+                                        new_scs.internal_variable_name =
+                                            name_property.value.get_content_owned();
+                                    }
                                 }
-                            }
-                            "ComponentClass" => {
-                                if let Some(object_property) =
-                                    cast!(Property, ObjectProperty, property)
-                                {
-                                    let import = actor_asset
-                                        .get_import(object_property.value)
-                                        .ok_or_else(|| {
-                                            io::Error::new(ErrorKind::Other, "No import")
-                                        })?
-                                        .clone();
-
-                                    second_import = Some(
-                                        actor_asset
-                                            .get_import(import.outer_index)
+                                "ComponentClass" => {
+                                    if let Some(object_property) =
+                                        cast!(Property, ObjectProperty, property)
+                                    {
+                                        let import = actor_asset
+                                            .get_import(object_property.value)
                                             .ok_or_else(|| {
                                                 io::Error::new(ErrorKind::Other, "No import")
                                             })?
-                                            .clone(),
-                                    );
-                                    first_import = Some(import);
+                                            .clone();
+
+                                        second_import = Some(
+                                            actor_asset
+                                                .get_import(import.outer_index)
+                                                .ok_or_else(|| {
+                                                    io::Error::new(ErrorKind::Other, "No import")
+                                                })?
+                                                .clone(),
+                                        );
+                                        first_import = Some(import);
+                                    }
                                 }
-                            }
-                            "ChildNodes" => {
-                                if let Some(array_property) =
-                                    cast!(Property, ArrayProperty, property)
-                                {
-                                    if array_property
-                                        .array_type
-                                        .as_ref()
-                                        .map(|e| e.get_content() == "ObjectProperty")
-                                        .unwrap_or(false)
+                                "ChildNodes" => {
+                                    if let Some(array_property) =
+                                        cast!(Property, ArrayProperty, property)
                                     {
-                                        for value_property in &array_property.value {
-                                            if let Some(object_property) =
-                                                cast!(Property, ObjectProperty, value_property)
-                                            {
-                                                known_parents.insert(
-                                                    object_property.value.index,
-                                                    known_node_category,
-                                                );
+                                        if array_property
+                                            .array_type
+                                            .as_ref()
+                                            .map(|e| e.is("ObjectProperty"))
+                                            .unwrap_or(false)
+                                        {
+                                            for value_property in &array_property.value {
+                                                if let Some(object_property) =
+                                                    cast!(Property, ObjectProperty, value_property)
+                                                {
+                                                    known_parents.insert(
+                                                        object_property.value.index,
+                                                        known_node_category,
+                                                    );
+                                                }
                                             }
                                         }
                                     }
                                 }
-                            }
-                            _ => {}
-                        }
+                                _ => {}
+                            })
+                        })?
                     }
 
                     if let (Some(first_import), Some(second_import)) = (first_import, second_import)

--- a/unreal_mod_integrator/src/lib.rs
+++ b/unreal_mod_integrator/src/lib.rs
@@ -341,11 +341,11 @@ fn bake_integrator_data(
         .into(),
     ]);
 
-    let export = asset.asset_data.exports.iter_mut().find(|e| {
-        e.get_base_export()
-            .object_name
-            .is("Default__IntegratorStatics_BP_C")
-    });
+    let export = asset
+        .asset_data
+        .exports
+        .iter_mut()
+        .find(|e| e.get_base_export().object_name == "Default__IntegratorStatics_BP_C");
     if export.is_none() {
         return Err(IntegrationError::corrupted_starter_pak().into());
     }

--- a/unreal_mod_integrator/src/lib.rs
+++ b/unreal_mod_integrator/src/lib.rs
@@ -342,7 +342,9 @@ fn bake_integrator_data(
     ]);
 
     let export = asset.asset_data.exports.iter_mut().find(|e| {
-        e.get_base_export().object_name.get_content() == "Default__IntegratorStatics_BP_C"
+        e.get_base_export()
+            .object_name
+            .is("Default__IntegratorStatics_BP_C")
     });
     if export.is_none() {
         return Err(IntegrationError::corrupted_starter_pak().into());


### PR DESCRIPTION
this pr essentially minimises a lot of the string creation in terms of FName content and getting from name map
the main change for this is making the `get_content` signature into `fn get_content<T>(&self, func: impl FnOnce(&str) -> T) -> T` and similarly for `get_name_reference`
Using a closure means that the lifetime of the name ref is valid which means you don't need to make a String
Of course you can still use the old behaviour with `get_content_owned` and similarly `get_name_reference_owned`
for some convenience the `is` and `ends_with` methods have been implemented for fnames since it's very common to check these things as shown in the amount of times they've already been used here
Unfortunately I couldn't figure out a way to cut the string creation in `asset/mod.rs` line 200 but other than that pretty much everything involving string creation from names where a string wasn't being stored somewhere has been optimised :)