### PR TITLE
unreal_asset: public bulk data offset for decoding

### DIFF
--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -272,7 +272,7 @@ pub struct Asset<C: Read + Seek> {
     /// Asset registry data offset
     asset_registry_data_offset: i32,
     /// Bulk data start offset
-    bulk_data_start_offset: i64,
+    pub bulk_data_start_offset: i64,
     /// World tile info offset
     world_tile_info_offset: i32,
     /// Preload dependency count


### PR DESCRIPTION
Just making the `bulk_data_offset` field public since it has uses for texture and lightmap decoding