### PR TITLE
allow mappings to actually be used

### DIFF
--- a/unreal_asset/README.md
+++ b/unreal_asset/README.md
@@ -42,7 +42,7 @@ use std::{
 let mut data_file = File::open("NPC_Onop_IO_Bech.uasset")?;
 let mut bulk_file = File::open("NPC_Onop_IO_Bech.uexp")?;
 
-let asset = Asset::new(data_file, Some(bulk_file), EngineVersion::VER_UE4_25)?;
+let asset = Asset::new(data_file, Some(bulk_file), EngineVersion::VER_UE4_25, None)?;
 println!("{:#?}", asset);
 ```
 

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -311,6 +311,7 @@ impl<'a, C: Read + Seek> Asset<C> {
         asset_data: C,
         bulk_data: Option<C>,
         engine_version: EngineVersion,
+        mappings: Option<Usmap>,
     ) -> Result<Self, Error> {
         let use_event_driven_loader = bulk_data.is_some();
 
@@ -373,6 +374,7 @@ impl<'a, C: Read + Seek> Asset<C> {
             parent_class: None,
         };
         asset.set_engine_version(engine_version);
+        asset.asset_data.mappings = mappings;
         asset.parse_data()?;
         Ok(asset)
     }

--- a/unreal_asset/src/lib.rs
+++ b/unreal_asset/src/lib.rs
@@ -14,7 +14,7 @@
 //! };
 //!
 //! let mut file = File::open("asset.uasset").unwrap();
-//! let mut asset = Asset::new(file, None, EngineVersion::VER_UE4_23).unwrap();
+//! let mut asset = Asset::new(file, None, EngineVersion::VER_UE4_23, None).unwrap();
 //!
 //! println!("{:#?}", asset);
 //! ```
@@ -31,7 +31,7 @@
 //!
 //! let mut file = File::open("asset.uasset").unwrap();
 //! let mut bulk_file = File::open("asset.uexp").unwrap();
-//! let mut asset = Asset::new(file, Some(bulk_file), EngineVersion::VER_UE4_23).unwrap();
+//! let mut asset = Asset::new(file, Some(bulk_file), EngineVersion::VER_UE4_23, None).unwrap();
 //!
 //! println!("{:#?}", asset);
 //! ```

--- a/unreal_asset/tests/ac7.rs
+++ b/unreal_asset/tests/ac7.rs
@@ -38,6 +38,7 @@ fn ac7() -> Result<(), Error> {
             Cursor::new(decrypted_data.as_slice()),
             Some(Cursor::new(decrypted_bulk.as_slice())),
             EngineVersion::VER_UE4_18,
+            None,
         )?;
 
         shared::verify_binary_equality(&decrypted_data, Some(&decrypted_bulk), &mut parsed)?;

--- a/unreal_asset/tests/cdo_modification.rs
+++ b/unreal_asset/tests/cdo_modification.rs
@@ -27,7 +27,12 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn cdo_modification() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None, EngineVersion::VER_UE4_23)?;
+    let mut asset = Asset::new(
+        Cursor::new(TEST_ASSET),
+        None,
+        EngineVersion::VER_UE4_23,
+        None,
+    )?;
 
     shared::verify_binary_equality(TEST_ASSET, None, &mut asset)?;
 

--- a/unreal_asset/tests/custom_serialization_structs_in_map.rs
+++ b/unreal_asset/tests/custom_serialization_structs_in_map.rs
@@ -32,6 +32,7 @@ fn custom_serialization_structs_in_map() -> Result<(), Error> {
         Cursor::new(ASSET_FILE),
         Some(Cursor::new(ASSET_BULK_FILE)),
         EngineVersion::VER_UE4_25,
+        None,
     )?;
 
     shared::verify_binary_equality(ASSET_FILE, Some(ASSET_BULK_FILE), &mut asset)?;

--- a/unreal_asset/tests/data_tables.rs
+++ b/unreal_asset/tests/data_tables.rs
@@ -24,7 +24,12 @@ const TEST_ASSET: &[u8] = include_bytes!(concat!(test_asset!(), ".uasset"));
 
 #[test]
 fn data_tables() -> Result<(), Error> {
-    let mut asset = Asset::new(Cursor::new(TEST_ASSET), None, EngineVersion::VER_UE4_18)?;
+    let mut asset = Asset::new(
+        Cursor::new(TEST_ASSET),
+        None,
+        EngineVersion::VER_UE4_18,
+        None,
+    )?;
 
     shared::verify_binary_equality(TEST_ASSET, None, &mut asset)?;
     assert!(shared::verify_all_exports_parsed(&asset));
@@ -59,6 +64,7 @@ fn data_tables() -> Result<(), Error> {
         Cursor::new(modified.as_slice()),
         None,
         EngineVersion::VER_UE4_18,
+        None,
     )?;
 
     shared::verify_binary_equality(&modified, None, &mut asset)?;

--- a/unreal_asset/tests/duplicate_name_map_entries.rs
+++ b/unreal_asset/tests/duplicate_name_map_entries.rs
@@ -22,6 +22,7 @@ fn duplicate_name_map_entries() -> Result<(), Error> {
         Cursor::new(ASSET_FILE),
         Some(Cursor::new(ASSET_BULK_FILE)),
         EngineVersion::VER_UE4_25,
+        None,
     )?;
 
     let mut has_duplicates = false;

--- a/unreal_asset/tests/general/astroneer_prebulk.rs
+++ b/unreal_asset/tests/general/astroneer_prebulk.rs
@@ -26,7 +26,12 @@ const TEST_ASSETS: [&[u8]; 5] = [
 #[test]
 fn astroneer_prebulk() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::VER_UE4_23)?;
+        let mut asset = Asset::new(
+            Cursor::new(test_asset),
+            None,
+            EngineVersion::VER_UE4_23,
+            None,
+        )?;
         shared::verify_binary_equality(test_asset, None, &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/bloodstained.rs
+++ b/unreal_asset/tests/general/bloodstained.rs
@@ -30,7 +30,12 @@ const TEST_ASSETS: [&[u8]; 6] = [
 #[test]
 fn bloodstained() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::VER_UE4_18)?;
+        let mut asset = Asset::new(
+            Cursor::new(test_asset),
+            None,
+            EngineVersion::VER_UE4_18,
+            None,
+        )?;
         shared::verify_binary_equality(test_asset, None, &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/codevein.rs
+++ b/unreal_asset/tests/general/codevein.rs
@@ -27,6 +27,7 @@ fn codevein() -> Result<(), Error> {
             Cursor::new(test_asset),
             Some(Cursor::new(asset_bulk)),
             EngineVersion::VER_UE4_18,
+            None,
         )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));

--- a/unreal_asset/tests/general/kismet_unicode.rs
+++ b/unreal_asset/tests/general/kismet_unicode.rs
@@ -27,6 +27,7 @@ fn kismet_unicode() -> Result<(), Error> {
             Cursor::new(test_asset),
             Some(Cursor::new(asset_bulk)),
             EngineVersion::VER_UE4_25,
+            None,
         )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
     }

--- a/unreal_asset/tests/general/misc426.rs
+++ b/unreal_asset/tests/general/misc426.rs
@@ -33,6 +33,7 @@ fn misc426() -> Result<(), Error> {
             Cursor::new(test_asset),
             Some(Cursor::new(asset_bulk)),
             EngineVersion::VER_UE4_26,
+            None,
         )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));

--- a/unreal_asset/tests/general/starlit_season.rs
+++ b/unreal_asset/tests/general/starlit_season.rs
@@ -33,6 +33,7 @@ fn starlit_season() -> Result<(), Error> {
             Cursor::new(test_asset),
             Some(Cursor::new(asset_bulk)),
             EngineVersion::VER_UE4_24,
+            None,
         )?;
         shared::verify_binary_equality(test_asset, Some(asset_bulk), &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));

--- a/unreal_asset/tests/general/tekken.rs
+++ b/unreal_asset/tests/general/tekken.rs
@@ -20,7 +20,12 @@ const TEST_ASSETS: [&[u8]; 1] = [include_bytes!(concat!(
 #[test]
 fn tekken() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::VER_UE4_14)?;
+        let mut asset = Asset::new(
+            Cursor::new(test_asset),
+            None,
+            EngineVersion::VER_UE4_14,
+            None,
+        )?;
         shared::verify_binary_equality(test_asset, None, &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/general/versioned.rs
+++ b/unreal_asset/tests/general/versioned.rs
@@ -23,7 +23,7 @@ const TEST_ASSETS: [&[u8]; 1] = [include_bytes!(concat!(
 #[test]
 fn versioned() -> Result<(), Error> {
     for test_asset in TEST_ASSETS {
-        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::UNKNOWN)?;
+        let mut asset = Asset::new(Cursor::new(test_asset), None, EngineVersion::UNKNOWN, None)?;
         shared::verify_binary_equality(test_asset, None, &mut asset)?;
         assert!(shared::verify_all_exports_parsed(&asset));
     }

--- a/unreal_asset/tests/improper_name_map_hashes.rs
+++ b/unreal_asset/tests/improper_name_map_hashes.rs
@@ -23,6 +23,7 @@ fn improper_name_map_hashes() -> Result<(), Error> {
         Cursor::new(ASSET_FILE),
         Some(Cursor::new(ASSET_BULK_FILE)),
         EngineVersion::VER_UE4_25,
+        None,
     )?;
 
     shared::verify_binary_equality(ASSET_FILE, Some(ASSET_BULK_FILE), &mut asset)?;

--- a/unreal_asset/tests/shared.rs
+++ b/unreal_asset/tests/shared.rs
@@ -15,7 +15,7 @@ pub(crate) fn verify_reparse<C: Read + Seek>(
     }
     asset.write_data(&mut cursor, bulk_cursor.as_mut())?;
 
-    Asset::new(cursor, bulk_cursor, engine_version)?;
+    Asset::new(cursor, bulk_cursor, engine_version, None)?;
 
     Ok(())
 }

--- a/unreal_asset/tests/ue5.rs
+++ b/unreal_asset/tests/ue5.rs
@@ -28,6 +28,7 @@ fn ue5() -> Result<(), Error> {
             Cursor::new(asset_data),
             Some(Cursor::new(bulk_data)),
             EngineVersion::VER_UE5_2,
+            None,
         )?;
 
         shared::verify_binary_equality(asset_data, Some(bulk_data), &mut parsed)?;

--- a/unreal_asset/tests/unknown_properties.rs
+++ b/unreal_asset/tests/unknown_properties.rs
@@ -25,6 +25,7 @@ fn unknown_properties() -> Result<(), Error> {
         Cursor::new(TEST_ASSET),
         Some(Cursor::new(TEST_BULK)),
         EngineVersion::VER_UE4_25,
+        None,
     )?;
     shared::verify_binary_equality(TEST_ASSET, Some(TEST_BULK), &mut asset)?;
     assert!(shared::verify_all_exports_parsed(&asset));

--- a/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
+++ b/unreal_mod_integrator/src/handlers/ue4_23/persistent_actors.rs
@@ -44,6 +44,7 @@ pub fn handle_persistent_actors(
         Cursor::new(LEVEL_TEMPLATE_ASSET),
         None,
         EngineVersion::VER_UE4_23,
+        None,
     )
     .map_err(|e| io::Error::new(ErrorKind::Other, e.to_string()))?;
 

--- a/unreal_mod_integrator/src/helpers.rs
+++ b/unreal_mod_integrator/src/helpers.rs
@@ -92,6 +92,7 @@ where
         Cursor::new(uasset),
         uexp.map(Cursor::new),
         engine_version,
+        None,
     )?)
 }
 

--- a/unreal_mod_integrator/src/lib.rs
+++ b/unreal_mod_integrator/src/lib.rs
@@ -446,6 +446,7 @@ pub fn integrate_mods<
             Cursor::new(LIST_OF_MODS_ASSET),
             list_of_mods_bulk.map(Cursor::new),
             C::ENGINE_VERSION,
+            None,
         )?;
         bake_mod_data(&mut list_of_mods, &read_mods)?;
         write_asset(
@@ -463,6 +464,7 @@ pub fn integrate_mods<
             Cursor::new(INTEGRATOR_STATICS_ASSET),
             integrator_statics_bulk.map(Cursor::new),
             C::ENGINE_VERSION,
+            None,
         )?;
 
         bake_integrator_data(


### PR DESCRIPTION
before exports were being parsed before the engine version could be set so unversioned assets didn't actually work :p