### PR TITLE
unreal_asset: update level export

### DIFF
--- a/unreal_asset/src/asset/mod.rs
+++ b/unreal_asset/src/asset/mod.rs
@@ -355,7 +355,7 @@ pub trait ExportReaderTrait: ArchiveReader + AssetTrait + Sized {
 
         let mut export: Export = export_class_type.get_content(|class| {
             Ok::<Export, Error>(match class {
-                "Level" => LevelExport::from_base(&base_export, self, next_starting)?.into(),
+                "Level" => LevelExport::from_base(&base_export, self)?.into(),
                 "StringTable" => StringTableExport::from_base(&base_export, self)?.into(),
                 "Enum" | "UserDefinedEnum" => EnumExport::from_base(&base_export, self)?.into(),
                 "Function" => FunctionExport::from_base(&base_export, self)?.into(),


### PR DESCRIPTION
updates the representation of `LevelExport` to include fields like model, level script actor explicitly. The reason that precomputed visibility handler and precomputed volume distance field aren't also represented is the same rationale behind not including StaticMesh and Texture exports. The extra data is simply too large and in most cases is not needed. If someone is really desparate they can parse the extras like I do [here](https://github.com/bananaturtlesandwich/stove/blob/main/src/extras/mesh.rs) for static meshes