### PR TITLE
name editing

### DIFF
--- a/unreal_asset/tests/name_editing.rs
+++ b/unreal_asset/tests/name_editing.rs
@@ -1,0 +1,16 @@
+#[test]
+fn name_editing() {
+    let mut map = unreal_asset::containers::name_map::NameMap::from_name_batch(&[
+        "never".to_string(),
+        "gonna".to_string(),
+        "give".to_string(),
+        "you".to_string(),
+        "up".to_string(),
+    ]);
+    let never = map.get_ref().create_fname(0, 0);
+    let content = never.get_owned_content();
+    // force creation of new name with same content
+    let i = map.get_mut().add_name_reference(content.clone(), true);
+    let new = map.get_ref().create_fname(i, 0);
+    assert_eq!(content, new.get_owned_content());
+}

--- a/unreal_asset/unreal_asset_base/src/containers/name_map.rs
+++ b/unreal_asset/unreal_asset_base/src/containers/name_map.rs
@@ -66,7 +66,7 @@ impl NameMap {
         self.name_map_index_list.push(name.clone());
         self.name_map_lookup
             .insert(hash, (self.name_map_index_list.len() - 1) as i32);
-        (self.name_map_lookup.len() - 1) as i32
+        (self.name_map_index_list.len() - 1) as i32
     }
 
     /// Get all FNames


### PR DESCRIPTION
uses name map index list length instead of lookup since for identical content with force duplicates the hashmap doesn't grow while the name map index list does