### PR TITLE
Fix UE4.27 cooked asset parsing

### DIFF
--- a/unreal_asset/src/asset.rs
+++ b/unreal_asset/src/asset.rs
@@ -565,7 +565,10 @@ impl<'a, C: Read + Seek> Asset<C> {
         }
 
         if self.legacy_file_version <= -8 {
-            let object_version_ue5: ObjectVersionUE5 = self.read_i32::<LE>()?.try_into()?;
+            let ue5_ver_raw = self.read_i32::<LE>()?;
+            let object_version_ue5: ObjectVersionUE5 = ue5_ver_raw
+                .try_into()
+                .unwrap_or(ObjectVersionUE5::UNKNOWN);
             if object_version_ue5 > ObjectVersionUE5::UNKNOWN {
                 self.asset_data.object_version_ue5 = object_version_ue5;
             }
@@ -670,9 +673,12 @@ impl<'a, C: Read + Seek> Asset<C> {
         self.compression_flags = self.read_u32::<LE>()?;
         let compression_block_count = self.read_u32::<LE>()?;
         if compression_block_count > 0 {
-            return Err(Error::invalid_file(
-                "Compression block count is not zero".to_string(),
-            ));
+            // UE4.27 cooked assets may have compressed chunks - skip them
+            // Each FCompressedChunk is 16 bytes (2x i64: UncompressedOffset + UncompressedSize)
+            for _i in 0..compression_block_count {
+                self.read_i64::<LE>()?;
+                self.read_i64::<LE>()?;
+            }
         }
 
         self.package_source = self.read_u32::<LE>()?;


### PR DESCRIPTION
## Summary
Fixes two issues that prevent parsing cooked assets from UE4.27 IoStore games (e.g. Return to Moria, DeltaForce):

- **ObjectVersionUE5 enum panic**: UE4.27 files with `legacy_file_version <= -8` write a small integer (e.g. `1`) in the UE5 version field. The `ObjectVersionUE5` enum jumps from `UNKNOWN = 0` to `INITIAL_VERSION = 1000` with no variants in between, so `TryFromPrimitive` panics. Fix: fall back to `UNKNOWN` for unrecognized values instead of propagating the error.

- **Compression block count hard rejection**: UE4.27 cooked assets use Zlib compression and have non-zero `compression_block_count`. The parser returned an error for any value > 0. Fix: skip the `FCompressedChunk` entries (16 bytes each: two i64 fields) so parsing can continue.

## Context
This is blocking [bananaturtlesandwich/stove#39](https://github.com/bananaturtlesandwich/stove/issues/39) — Stove (the cooked .umap editor) cannot open any UE4.27 map files due to these two errors in `unreal_asset`.

## Changes
- `unreal_asset/src/asset.rs` line 568: `try_into()` → `try_into().unwrap_or(UNKNOWN)` for ObjectVersionUE5
- `unreal_asset/src/asset.rs` lines 675-678: Skip compression block entries instead of rejecting

## Test plan
- [ ] Open a cooked .umap from a UE4.27 IoStore game (Return to Moria, DeltaForce)
- [ ] Verify the file parses without "No discriminant in enum ObjectVersionUE5" error
- [ ] Verify the file parses without "Compression block count is not zero" error
- [ ] Verify UE5 assets still parse correctly (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)